### PR TITLE
Preserve and date assembled exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Plan → Loop Start → Current Shot → stock H3 conditioning
 Loop End manifest → Assemble
 ```
 
+The Assemble `filename` field accepts ComfyUI-style date tokens such as
+`%date:yyyy-MM-dd%`, along with `%year%`, `%month%`, `%day%`, `%hour%`,
+`%minute%`, and `%second%`. Assemble preserves existing exports: when the
+requested MP4 already exists, the next file receives `_001`, `_002`, and so on
+instead of replacing it.
+
 For a non-looping experiment, open the
 [three-angle guitar Ref2VA workflow](<example_workflows/EXPERIMENTAL MiniMax H3 Three-Angle Guitar Ref2VA.json>).
 It loads `3ClbaJYWVO4_000030.mp4`, turns the source performance into a

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -26,6 +26,7 @@ import subprocess
 import time
 import uuid
 import wave
+from datetime import datetime
 from fractions import Fraction
 from typing import Any
 
@@ -108,6 +109,46 @@ def _safe_name(value: str, fallback: str = "chain") -> str:
     text = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value or "").strip())
     text = text.strip("._-")
     return (text or fallback)[:96]
+
+
+def _expand_filename_date(value: str, now: datetime | None = None) -> str:
+    """Expand ComfyUI-style date tokens before filename sanitization."""
+    current = now or datetime.now()
+    replacements = {
+        "yyyy": "%Y", "yy": "%y", "MM": "%m", "dd": "%d",
+        "HH": "%H", "hh": "%I", "mm": "%M", "ss": "%S",
+    }
+
+    def replace_date(match: re.Match[str]) -> str:
+        pattern = match.group(1)
+        strftime_pattern = re.sub(
+            r"yyyy|yy|MM|dd|HH|hh|mm|ss",
+            lambda token: replacements[token.group(0)],
+            pattern,
+        )
+        return current.strftime(strftime_pattern)
+
+    text = re.sub(r"%date:([^%]+)%", replace_date, str(value or ""))
+    simple_tokens = {
+        "%year%": "%Y", "%month%": "%m", "%day%": "%d",
+        "%hour%": "%H", "%minute%": "%M", "%second%": "%S",
+    }
+    for token, pattern in simple_tokens.items():
+        text = text.replace(token, current.strftime(pattern))
+    return text
+
+
+def _available_versioned_path(path: str) -> str:
+    """Return path unchanged when free, otherwise add a numeric version."""
+    if not os.path.exists(path):
+        return path
+    root, extension = os.path.splitext(path)
+    version = 1
+    while True:
+        candidate = "%s_%03d%s" % (root, version, extension)
+        if not os.path.exists(candidate):
+            return candidate
+        version += 1
 
 
 def _prompt_text(value: Any, label: str) -> str:
@@ -3690,7 +3731,9 @@ class MiniMaxH3ChainAssemble:
                     "default": "final",
                     "tooltip": "Final MP4 basename inside this chain's output "
                                "folder. The .mp4 extension is added "
-                               "automatically."}),
+                               "automatically. Supports date tokens such as "
+                               "%date:yyyy-MM-dd%. Existing files are preserved "
+                               "by adding _001, _002, and so on."}),
                 "audio_bitrate": ("INT", {
                     "default": 256, "min": 64, "max": 512,
                     "tooltip": "AAC bitrate in kilobits per second for the "
@@ -3721,7 +3764,7 @@ class MiniMaxH3ChainAssemble:
         return float("NaN")
 
     def assemble(self, manifest, audio_source, filename, audio_bitrate,
-                 source_audio=None):
+                 source_audio=None, overwrite_existing=False):
         segments = _validate_manifest(manifest)
         prelude = _validate_prelude(manifest)
         selected = audio_source
@@ -3769,8 +3812,10 @@ class MiniMaxH3ChainAssemble:
         run_dir = os.path.join(_output_root(), "h3_chains", run_name)
         final_dir = os.path.join(run_dir, "final")
         os.makedirs(final_dir, exist_ok=True)
-        final_name = _safe_name(filename, "final")
+        final_name = _safe_name(_expand_filename_date(filename), "final")
         final_path = os.path.join(final_dir, final_name + ".mp4")
+        if not overwrite_existing:
+            final_path = _available_versioned_path(final_path)
         concat_path = os.path.join(final_dir, ".concat.txt")
         video_tmp = os.path.join(final_dir, ".video.tmp.mp4")
         final_tmp = os.path.join(final_dir, ".final.tmp.mp4")
@@ -3877,7 +3922,8 @@ def _assemble_review_partial(
     warning = ""
     try:
         result = assembler.assemble(
-            manifest, selected, filename, 192, source_audio)
+            manifest, selected, filename, 192, source_audio,
+            overwrite_existing=True)
     except Exception as audio_error:
         if selected == "none":
             raise
@@ -3885,7 +3931,8 @@ def _assemble_review_partial(
             "H3 Chain partial audio assembly failed; saving silent video: %s",
             audio_error)
         result = assembler.assemble(
-            manifest, "none", filename, 192, source_audio)
+            manifest, "none", filename, 192, source_audio,
+            overwrite_existing=True)
         warning = "audio unavailable, so the partial video is silent (%s)" % audio_error
     return str(result["result"][0]), warning
 

--- a/tests/_chain_smoke_test.py
+++ b/tests/_chain_smoke_test.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import threading
 import time
+from datetime import datetime
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -84,6 +85,19 @@ class FakeDynamicPrompt:
 
 def main():
     package, chain = load_package()
+
+    fixed_now = datetime(2026, 8, 11, 14, 5, 9)
+    assert chain._expand_filename_date(
+        "render_%date:yyyy-MM-dd%_%hour%-%minute%-%second%", fixed_now
+    ) == "render_2026-08-11_14-05-09"
+    with tempfile.TemporaryDirectory() as version_dir:
+        original = pathlib.Path(version_dir) / "render.mp4"
+        original.touch()
+        (pathlib.Path(version_dir) / "render_001.mp4").touch()
+        assert chain._available_versioned_path(str(original)).endswith(
+            "render_002.mp4"
+        )
+    print("assemble filenames: date expansion and collision versioning passed")
 
     async def review_route_check():
         token = "review-route-smoke"


### PR DESCRIPTION
## What changed

- expand ComfyUI-style date tokens in the Assemble `filename` field before sanitizing it
- support `%date:yyyy-MM-dd%` and the simple year/month/day/hour/minute/second tokens
- preserve an existing final MP4 by selecting `_001`, `_002`, and subsequent versions
- keep internal review partial exports replaceable so retry behavior remains unchanged
- document the filename behavior and add focused smoke coverage

## Why

Assemble previously sanitized `%date:yyyy-MM-dd%` as literal text. It also used `os.replace` on the requested final path, silently overwriting an earlier export with the same filename.

This makes Assemble behave more like ComfyUI's save nodes: useful filename dates work and completed outputs are retained.

## Validation

- `python -m py_compile chain_nodes.py tests/_chain_smoke_test.py`
- focused smoke assertions pass for a fixed date and collision sequence (`render.mp4`, `render_001.mp4` -> `render_002.mp4`)
- the full CPU smoke test progressed through assembly, resume, review, and recursion coverage, then hit the pre-existing workflow-archive suffix assertion under current ComfyUI 0.31.0; that assertion is unrelated to this patch
