### PR TITLE
Decode ffmpeg/ffprobe output as UTF-8, not the locale codepage

### DIFF
--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -3198,9 +3198,15 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _run_ffmpeg(command: list[str], timeout_seconds: float | None = None) -> None:
     try:
+        # ffmpeg writes UTF-8. text=True alone decodes with the locale's
+        # preferred encoding, which on a non-UTF-8 Windows console (cp932,
+        # cp1251, ...) raises UnicodeDecodeError inside subprocess's reader
+        # threads. Those threads die, result.stderr comes back truncated or
+        # empty, and a genuine ffmpeg failure below reports no reason at all.
+        # Decode as UTF-8 and never let diagnostics be the thing that fails.
         result = subprocess.run(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-            timeout=timeout_seconds)
+            encoding="utf-8", errors="replace", timeout=timeout_seconds)
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
             "ffmpeg timed out after %.1f seconds" % float(timeout_seconds)) from exc

--- a/tests/_chain_smoke_test.py
+++ b/tests/_chain_smoke_test.py
@@ -737,7 +737,7 @@ def main():
             external_duration = float(subprocess.check_output([
                 "ffprobe", "-v", "error", "-show_entries", "format=duration",
                 "-of", "default=nw=1:nk=1", str(external_path),
-            ], text=True).strip())
+            ], text=True, encoding="utf-8", errors="replace").strip())
             assert abs(external_duration - 14 / 24) < 0.05
             assert "existing-video prelude" in external_result["ui"]["text"][0]
             external_original_which = chain.shutil.which
@@ -863,7 +863,7 @@ def main():
                 "ffprobe", "-v", "error", "-show_entries", "format_tags",
                 "-of", "json",
                 str(chain._absolute_output_path(segment1["segment"])),
-            ], text=True))["format"]["tags"]
+            ], text=True, encoding="utf-8", errors="replace"))["format"]["tags"]
             assert embedded_tags["comment"] == "first"
             assert embedded_tags["h3_prompt"] == "first"
             assert json.loads(embedded_tags["workflow"])["nodes"][0][
@@ -921,7 +921,7 @@ def main():
             streams = subprocess.check_output([
                 "ffprobe", "-v", "error", "-show_entries", "stream=codec_type",
                 "-of", "csv=p=0", str(review_path),
-            ], text=True).splitlines()
+            ], text=True, encoding="utf-8", errors="replace").splitlines()
             assert "video" in streams and "audio" in streams
 
             fallback_review_audio = audio_for_frames(5)
@@ -1231,7 +1231,7 @@ def main():
                         "ffprobe", "-v", "error", "-show_entries",
                         "stream=codec_type", "-of", "csv=p=0",
                         str(partial_path),
-                    ], text=True).splitlines()
+                    ], text=True, encoding="utf-8", errors="replace").splitlines()
                     assert "video" in streams and "audio" in streams
                 finally:
                     chain.PromptServer = original_server
@@ -1331,14 +1331,14 @@ def main():
             source_tags = json.loads(subprocess.check_output([
                 "ffprobe", "-v", "error", "-show_entries", "format_tags",
                 "-of", "json", str(source_path),
-            ], text=True))["format"]["tags"]
+            ], text=True, encoding="utf-8", errors="replace"))["format"]["tags"]
             assert json.loads(source_tags["workflow"])["nodes"][0][
                 "type"] == "MiniMaxH3ChainPlan"
             assert json.loads(source_tags["h3_manifest"])["clip_count"] == 2
             duration = float(subprocess.check_output([
                 "ffprobe", "-v", "error", "-show_entries", "format=duration",
                 "-of", "default=nw=1:nk=1", str(source_path),
-            ], text=True).strip())
+            ], text=True, encoding="utf-8", errors="replace").strip())
             assert abs(duration - 9 / 24) < 0.05
             short_silent_manifest = dict(manifest)
             short_silent_manifest["compatibility"] = dict(


### PR DESCRIPTION
## The symptom

On a Japanese Windows install, a normal chain run prints this during assembly:

```
Exception in thread Thread-16 (_readerthread):
Traceback (most recent call last):
  File "threading.py", line 1044, in _bootstrap_inner
  File "threading.py", line 995, in run
  File "subprocess.py", line 1615, in _readerthread
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 in position 3051: illegal multibyte sequence
```

The mp4 comes out correct, so it looks cosmetic.

## Why it isn't cosmetic

`subprocess.run(..., text=True)` decodes with `locale.getpreferredencoding()`. That is `cp932` here, and ffmpeg writes UTF-8, so the reader threads die mid-read. `result.stderr` then comes back empty — and the branch immediately below is the one that needs it:

```python
if result.returncode:
    tail = "\n".join(result.stderr.splitlines()[-20:])
    raise RuntimeError("ffmpeg failed (%d):\n%s" % (result.returncode, tail))
```

So on any non-UTF-8 locale, a real ffmpeg failure reports a return code and nothing else. The one thing that has to survive a failure is the explanation of it.

## The fix

`encoding="utf-8", errors="replace"` on the call. `replace` rather than strict, because a garbled character in a diagnostic must never become a second failure that hides the first.

## Verification

Reproduced and confirmed fixed on the affected locale — a child process writing the same `0x86` byte:

```
locale preferred encoding: cp932

--- text=True only ---
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 in position 3
stdout: None

--- encoding="utf-8", errors="replace" ---
stdout: decoded cleanly
```

`tests/_node_smoke_test.py` still passes.

## Also included

The six `ffprobe` calls in `tests/_chain_smoke_test.py` share the pattern, and two of them read `format_tags`, which carries the persisted scene prompts. A non-ASCII prompt would fail those assertions on the same machines, so they are fixed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
