### PR TITLE
Feature/review gate frame capture

### DIFF
--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -27293,6 +27293,86 @@ async def _project_asset_delete(request):
         return web.json_response({"error": str(exc)}, status=400)
 
 
+def _capture_frame_video_path(filename: Any, subfolder: Any, kind: Any) -> str:
+    """Resolve a ComfyUI /view (filename, subfolder, type) triple to a file."""
+    directories = {
+        "input": folder_paths.get_input_directory(),
+        "output": folder_paths.get_output_directory(),
+        "temp": folder_paths.get_temp_directory(),
+    }
+    root = directories.get(str(kind or "output").strip().lower())
+    if root is None:
+        raise ValueError("Video source type must be input, output, or temp.")
+    name = str(filename or "").strip()
+    if not name:
+        raise ValueError("Video filename cannot be blank.")
+    sub = str(subfolder or "").strip()
+    candidate = os.path.join(root, sub, name) if sub else os.path.join(root, name)
+    return _confined_media_path(candidate, "Video source")
+
+
+def _capture_video_frame(video_path: str, time_seconds: float, output_path: str) -> None:
+    ffmpeg = _usable_ffmpeg()
+    if ffmpeg is None:
+        raise RuntimeError("Capturing a video frame requires a working ffmpeg.")
+    offset = max(0.0, float(time_seconds))
+    temporary = "%s.%s.tmp.png" % (output_path, uuid.uuid4().hex)
+    command = [
+        ffmpeg, "-hide_banner", "-loglevel", "error", "-y",
+        "-ss", "%.6f" % offset, "-i", video_path,
+        "-frames:v", "1", "-an", temporary,
+    ]
+    try:
+        _run_ffmpeg(command, timeout_seconds=60.0)
+        if not os.path.isfile(temporary) or os.path.getsize(temporary) < 1:
+            raise RuntimeError("ffmpeg produced an empty captured frame.")
+        os.replace(temporary, output_path)
+    finally:
+        _safe_unlink(temporary)
+
+
+def _project_asset_capture_frame_sync(
+        project: Any, video_path: Any, subfolder: Any, source_type: Any,
+        time_seconds: Any, tag: Any, role: Any,
+        folder_id: Any) -> dict[str, Any]:
+    source = _capture_frame_video_path(video_path, subfolder, source_type)
+    store = _project_asset_store()
+    temporary = store.upload_path(project, "frame_capture.png")
+    try:
+        _capture_video_frame(source, float(time_seconds or 0.0), temporary)
+        result = store.import_file(
+            project, temporary, role=role or "", tag=tag or "",
+            original_name="frame_capture.png", source_kind="frame_capture")
+        if folder_id not in (None, ""):
+            asset_id = result["asset"]["id"]
+            catalog = store.update(project, asset_id, {"folder_id": folder_id})
+            asset = next(
+                item for item in catalog["assets"]
+                if str(item.get("id") or "") == asset_id)
+            result = {"catalog": catalog, "asset": asset}
+        return result
+    finally:
+        _safe_unlink(temporary)
+
+
+async def _project_asset_capture_frame(request):
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise ValueError("Frame capture request must be a JSON object.")
+        result = await asyncio.to_thread(
+            _project_asset_capture_frame_sync,
+            body.get("project", ""), body.get("filename", ""),
+            body.get("subfolder", ""), body.get("type", "output"),
+            body.get("time_seconds", 0.0), body.get("tag", ""),
+            body.get("role", ""),
+            body.get("folder_id") if "folder_id" in body else None)
+        return web.json_response(result)
+    except (OSError, RuntimeError, TypeError, ValueError,
+            json.JSONDecodeError) as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+
+
 async def _project_asset_media(request):
     try:
         project = request.query.get("project", "")
@@ -27398,6 +27478,9 @@ if (PromptServer is not None and web is not None and
     PromptServer.instance.routes.post(
         "/minimax_h3_context_loop/project-assets/import")(
             _project_asset_import)
+    PromptServer.instance.routes.post(
+        "/minimax_h3_context_loop/project-assets/capture-frame")(
+            _project_asset_capture_frame)
     PromptServer.instance.routes.post(
         "/minimax_h3_context_loop/project-assets/update")(
             _project_asset_update)

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -27340,8 +27340,9 @@ def _project_asset_capture_frame_sync(
     temporary = store.upload_path(project, "frame_capture.png")
     try:
         _capture_video_frame(source, float(time_seconds or 0.0), temporary)
+        resolved_tag = store.resolve_capture_tag(project, tag, "frame_capture")
         result = store.import_file(
-            project, temporary, role=role or "", tag=tag or "",
+            project, temporary, role=role or "", tag=resolved_tag,
             original_name="frame_capture.png", source_kind="frame_capture")
         if folder_id not in (None, ""):
             asset_id = result["asset"]["id"]

--- a/project_assets.py
+++ b/project_assets.py
@@ -123,6 +123,43 @@ def _unique_tag(catalog: dict[str, Any], value: Any, fallback: str,
     return tag
 
 
+_TRAILING_DIGITS_RE = re.compile(r"^(.*?)(\d+)$")
+
+
+def _capture_family_tag(catalog: dict[str, Any], value: Any, fallback: str) -> str:
+    """Uniquify a captured-frame tag as an updated take of its family.
+
+    Unlike _unique_tag (which appends "_2", "_3", ... on any collision),
+    a tag reused for a video-frame capture is meant to read as an updated
+    take of the same subject: @char-sammy -> @char-sammy1, then
+    @char-sammy2, and so on, with no underscore before the number.
+    """
+    tag = _safe_tag(value, fallback)
+    used = {
+        str(item.get("tag") or "") for item in catalog.get("assets", [])
+        if bool(item.get("enabled", True))
+    }
+    if tag not in used:
+        return tag
+    match = _TRAILING_DIGITS_RE.match(tag)
+    stem = match.group(1) if match else tag
+    highest = 0
+    for other in used:
+        if other == stem or not other.startswith(stem):
+            continue
+        suffix = other[len(stem):]
+        if suffix.isdigit():
+            highest = max(highest, int(suffix))
+    ordinal = highest + 1
+    suffix = str(ordinal)
+    candidate = stem[:64 - len(suffix)] + suffix
+    while candidate in used:
+        ordinal += 1
+        suffix = str(ordinal)
+        candidate = stem[:64 - len(suffix)] + suffix
+    return candidate
+
+
 def _image_resampling(value: Any):
     if Image is None:
         raise RuntimeError("Pillow is required for project image variants.")
@@ -697,6 +734,11 @@ class ProjectAssetStore:
         result["catalog"] = self._save_catalog(bound_catalog)
         result["bound_slot_id"] = wanted
         return result
+
+    def resolve_capture_tag(self, project: Any, tag: Any, fallback: str) -> str:
+        """Uniquify a tag for a captured video frame (see _capture_family_tag)."""
+        catalog = self.load(project, create=True)
+        return _capture_family_tag(catalog, tag, fallback)
 
     def import_file(self, project: Any, source_path: Any, *, role: Any = "",
                     tag: Any = "", original_name: Any = "",

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -900,10 +900,16 @@ function mount(node) {
                 `/minimax_h3_context_loop/project-assets?${new URLSearchParams({project})}`);
             const catalog = await response.json();
             if (!response.ok) throw new Error(catalog.error || `HTTP ${response.status}`);
+            console.log(
+                `[H3 capture] fetched ${catalog.assets?.length ?? 0} asset(s) for ` +
+                `project ${JSON.stringify(project)}`, catalog);
             return (catalog.assets ?? [])
                 .map((item) => String(item.tag || "").trim())
                 .filter(Boolean);
-        } catch (_error) {
+        } catch (error) {
+            console.warn(
+                `[H3 capture] failed to fetch existing tags for project ` +
+                `${JSON.stringify(project)}:`, error);
             return [];
         }
     }
@@ -944,6 +950,9 @@ function mount(node) {
         const title = document.createElement("div");
         title.className = "h3r-capture-title";
         title.textContent = `Save frame at ${captureTime.toFixed(2)}s`;
+        const projectLine = document.createElement("div");
+        projectLine.className = "h3r-capture-hint";
+        projectLine.textContent = `Carousel project: ${project}`;
         const preview = document.createElement("img");
         preview.className = "h3r-capture-preview";
         try { preview.src = canvas.toDataURL("image/png"); } catch (_error) {}
@@ -1024,7 +1033,7 @@ function mount(node) {
         saveButton.className = "h3r-button";
         saveButton.textContent = "Save to Carousel";
         actionsRow.append(cancelButton, saveButton);
-        card.append(title, preview, tagField, hint, error, actionsRow);
+        card.append(title, projectLine, preview, tagField, hint, error, actionsRow);
         overlay.append(card);
         root.append(overlay);
         tagInput.focus();

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -217,7 +217,7 @@ function injectStyles() {
             border:1px solid #343b4b; border-radius:6px; background:#08090c; }
         .h3r-capture-title { font-weight:700; color:#a9c2ff; }
         .h3r-capture-field { display:flex; flex-direction:column; gap:4px; color:#aeb5c5; }
-        .h3r-capture-tag-row { display:flex; gap:0; }
+        .h3r-capture-tag-row { display:flex; gap:0; position:relative; }
         .h3r-capture-tag { flex:1 1 auto; min-width:0; width:100%; padding:6px 7px;
             border:1px solid #56637e; border-right:0; border-radius:5px 0 0 5px;
             background:#101218; color:#eef1f7; }
@@ -225,6 +225,12 @@ function injectStyles() {
             border:1px solid #56637e; border-radius:0 5px 5px 0; background:#232837;
             color:#eef1f7; cursor:pointer; }
         .h3r-capture-tag-picker:hover { background:#343b4b; }
+        .h3r-capture-tag-menu { position:absolute; top:calc(100% + 3px); left:0; right:0;
+            z-index:40; max-height:150px; overflow-y:auto; border:1px solid #56637e;
+            border-radius:5px; background:#101218; box-shadow:0 6px 18px rgba(0,0,0,.5); }
+        .h3r-capture-tag-option { padding:6px 8px; color:#eef1f7; cursor:pointer; }
+        .h3r-capture-tag-option:hover { background:#232837; }
+        .h3r-capture-tag-empty { padding:6px 8px; color:#8b93a6; }
         .h3r-capture-hint { color:#8b93a6; font-size:11px; }
         .h3r-capture-error { color:#ff9a9a; }
         .h3r-capture-actions { display:flex; justify-content:flex-end; gap:7px; }
@@ -947,10 +953,7 @@ function mount(node) {
         const tagInput = document.createElement("input");
         tagInput.className = "h3r-capture-tag";
         tagInput.placeholder = "e.g. hero_pose";
-        const tagOptionsId = `h3r-capture-tag-options-${node.id ?? Math.random().toString(36).slice(2)}`;
-        tagInput.setAttribute("list", tagOptionsId);
-        const tagOptions = document.createElement("datalist");
-        tagOptions.id = tagOptionsId;
+        tagInput.autocomplete = "off";
         const tagPickerRow = document.createElement("div");
         tagPickerRow.className = "h3r-capture-tag-row";
         const tagPickerButton = document.createElement("button");
@@ -958,17 +961,49 @@ function mount(node) {
         tagPickerButton.className = "h3r-capture-tag-picker";
         tagPickerButton.textContent = "▾";
         tagPickerButton.title = "Choose from existing tags";
-        tagPickerButton.addEventListener("click", () => {
-            tagInput.focus();
-            if (typeof tagInput.showPicker === "function") {
-                try { tagInput.showPicker(); return; } catch (_error) { /* fall through */ }
+        const tagMenu = document.createElement("div");
+        tagMenu.className = "h3r-capture-tag-menu";
+        tagMenu.hidden = true;
+        let knownTags = [];
+        function renderTagMenu(filter = "") {
+            const needle = filter.trim().toLowerCase();
+            const matches = needle
+                ? knownTags.filter((tag) => tag.toLowerCase().includes(needle))
+                : knownTags;
+            tagMenu.replaceChildren(...matches.map((tag) => {
+                const option = document.createElement("div");
+                option.className = "h3r-capture-tag-option";
+                option.textContent = tag;
+                option.addEventListener("mousedown", (event) => {
+                    // mousedown (not click) fires before the input's blur hides the menu.
+                    event.preventDefault();
+                    tagInput.value = tag;
+                    tagMenu.hidden = true;
+                });
+                return option;
+            }));
+            if (!matches.length) {
+                const empty = document.createElement("div");
+                empty.className = "h3r-capture-tag-empty";
+                empty.textContent = knownTags.length ? "No matching tags." : "No tags yet.";
+                tagMenu.append(empty);
             }
-            // showPicker() on a list-bound input isn't supported everywhere;
-            // a synthetic keystroke still reopens the browser's own suggestion
-            // dropdown for text inputs bound to a <datalist>.
-            tagInput.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown"}));
+        }
+        tagPickerButton.addEventListener("mousedown", (event) => {
+            // Prevent the input from blurring (which would hide the menu)
+            // before this toggle runs.
+            event.preventDefault();
+            const opening = tagMenu.hidden;
+            tagInput.focus();
+            tagMenu.hidden = !opening;
+            if (opening) renderTagMenu(tagInput.value);
         });
-        tagPickerRow.append(tagInput, tagPickerButton, tagOptions);
+        tagInput.addEventListener("input", () => {
+            tagMenu.hidden = false;
+            renderTagMenu(tagInput.value);
+        });
+        tagInput.addEventListener("blur", () => { tagMenu.hidden = true; });
+        tagPickerRow.append(tagInput, tagPickerButton, tagMenu);
         tagField.append(tagPickerRow);
         const hint = document.createElement("div");
         hint.className = "h3r-capture-hint";
@@ -995,11 +1030,8 @@ function mount(node) {
         tagInput.focus();
 
         fetchExistingTags(project).then((tags) => {
-            tagOptions.replaceChildren(...tags.map((tag) => {
-                const option = document.createElement("option");
-                option.value = tag;
-                return option;
-            }));
+            knownTags = tags;
+            if (!tagMenu.hidden) renderTagMenu(tagInput.value);
         });
 
         cancelButton.addEventListener("click", () => overlay.remove());

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -217,8 +217,14 @@ function injectStyles() {
             border:1px solid #343b4b; border-radius:6px; background:#08090c; }
         .h3r-capture-title { font-weight:700; color:#a9c2ff; }
         .h3r-capture-field { display:flex; flex-direction:column; gap:4px; color:#aeb5c5; }
-        .h3r-capture-tag { width:100%; padding:6px 7px; border:1px solid #56637e;
-            border-radius:5px; background:#101218; color:#eef1f7; }
+        .h3r-capture-tag-row { display:flex; gap:0; }
+        .h3r-capture-tag { flex:1 1 auto; min-width:0; width:100%; padding:6px 7px;
+            border:1px solid #56637e; border-right:0; border-radius:5px 0 0 5px;
+            background:#101218; color:#eef1f7; }
+        .h3r-capture-tag-picker { flex:0 0 auto; width:28px; padding:6px 0;
+            border:1px solid #56637e; border-radius:0 5px 5px 0; background:#232837;
+            color:#eef1f7; cursor:pointer; }
+        .h3r-capture-tag-picker:hover { background:#343b4b; }
         .h3r-capture-hint { color:#8b93a6; font-size:11px; }
         .h3r-capture-error { color:#ff9a9a; }
         .h3r-capture-actions { display:flex; justify-content:flex-end; gap:7px; }
@@ -941,14 +947,34 @@ function mount(node) {
         const tagInput = document.createElement("input");
         tagInput.className = "h3r-capture-tag";
         tagInput.placeholder = "e.g. hero_pose";
-        tagInput.setAttribute("list", "h3r-capture-tag-options");
+        const tagOptionsId = `h3r-capture-tag-options-${node.id ?? Math.random().toString(36).slice(2)}`;
+        tagInput.setAttribute("list", tagOptionsId);
         const tagOptions = document.createElement("datalist");
-        tagOptions.id = "h3r-capture-tag-options";
-        tagField.append(tagInput, tagOptions);
+        tagOptions.id = tagOptionsId;
+        const tagPickerRow = document.createElement("div");
+        tagPickerRow.className = "h3r-capture-tag-row";
+        const tagPickerButton = document.createElement("button");
+        tagPickerButton.type = "button";
+        tagPickerButton.className = "h3r-capture-tag-picker";
+        tagPickerButton.textContent = "▾";
+        tagPickerButton.title = "Choose from existing tags";
+        tagPickerButton.addEventListener("click", () => {
+            tagInput.focus();
+            if (typeof tagInput.showPicker === "function") {
+                try { tagInput.showPicker(); return; } catch (_error) { /* fall through */ }
+            }
+            // showPicker() on a list-bound input isn't supported everywhere;
+            // a synthetic keystroke still reopens the browser's own suggestion
+            // dropdown for text inputs bound to a <datalist>.
+            tagInput.dispatchEvent(new KeyboardEvent("keydown", {key: "ArrowDown"}));
+        });
+        tagPickerRow.append(tagInput, tagPickerButton, tagOptions);
+        tagField.append(tagPickerRow);
         const hint = document.createElement("div");
         hint.className = "h3r-capture-hint";
-        hint.textContent = "Pick an existing tag to save this as an updated take — " +
-            "a number is appended automatically (e.g. hero_pose_2) so both stay in the Carousel.";
+        hint.textContent = "Choose an existing tag (or type a new one) to save this as an " +
+            "updated take — a number is appended automatically (e.g. char-sammy1, " +
+            "char-sammy2, ...) so every take stays in the Carousel.";
         const error = document.createElement("div");
         error.className = "h3r-capture-error";
         error.hidden = true;

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -27,6 +27,7 @@ import {
 const NODE_NAME = "MiniMaxH3ChainReview";
 const PLAN_NAME = "MiniMaxH3ChainPlan";
 const PLAN_NAMES = new Set([PLAN_NAME, "MiniMaxH3ChainPlanModern"]);
+const ASSET_CAROUSEL_NAMES = new Set(["MiniMaxH3ProjectAssetManager"]);
 const PROMPT_EDITOR_SETTING = "MiniMaxH3ContexLoop.ReviewGate.PromptEditor";
 const VIDEO_HEIGHT_PROPERTY = "h3_chain_review_video_height";
 const PROMPT_HEIGHT_PROPERTY = "h3_chain_review_prompt_height";
@@ -891,6 +892,13 @@ function mount(node) {
     captureRow.append(captureButton, captureStatus);
 
     function captureTargetProject() {
+        // The Asset Carousel's project can be renamed independently of any
+        // upstream Plan's run_name, so prefer reading it directly from a
+        // connected (or any on-canvas) Carousel node before falling back.
+        const carouselNode = findUpstreamNode(node, ASSET_CAROUSEL_NAMES) ??
+            allNodes(app.graph).find((item) => ASSET_CAROUSEL_NAMES.has(nodeType(item)));
+        const carouselProject = carouselNode?._h3ProjectAssetCurrentProject?.();
+        if (carouselProject) return carouselProject;
         return planResumeContext(node).runName;
     }
 
@@ -931,8 +939,7 @@ function mount(node) {
         try {
             project = captureTargetProject();
         } catch (_error) {
-            captureStatus.textContent = "Open a connected Plan to name the target project.";
-            return;
+            project = "";
         }
         closeCaptureDialog();
 
@@ -950,9 +957,25 @@ function mount(node) {
         const title = document.createElement("div");
         title.className = "h3r-capture-title";
         title.textContent = `Save frame at ${captureTime.toFixed(2)}s`;
-        const projectLine = document.createElement("div");
-        projectLine.className = "h3r-capture-hint";
-        projectLine.textContent = `Carousel project: ${project}`;
+        const projectField = document.createElement("label");
+        projectField.className = "h3r-capture-field";
+        projectField.append("Carousel project");
+        const projectInput = document.createElement("input");
+        projectInput.className = "h3r-capture-tag";
+        projectInput.value = project;
+        projectInput.placeholder = "e.g. sammys_house";
+        projectInput.title = "The Asset Carousel node's own project name, which can differ " +
+            "from any connected Plan's run_name. Guessed from an on-canvas Carousel node " +
+            "when possible — edit it if it guessed wrong.";
+        projectField.append(projectInput);
+        projectInput.addEventListener("change", () => {
+            knownTags = [];
+            renderTagMenu(tagInput.value);
+            fetchExistingTags(projectInput.value.trim()).then((tags) => {
+                knownTags = tags;
+                if (!tagMenu.hidden) renderTagMenu(tagInput.value);
+            });
+        });
         const preview = document.createElement("img");
         preview.className = "h3r-capture-preview";
         try { preview.src = canvas.toDataURL("image/png"); } catch (_error) {}
@@ -1033,12 +1056,12 @@ function mount(node) {
         saveButton.className = "h3r-button";
         saveButton.textContent = "Save to Carousel";
         actionsRow.append(cancelButton, saveButton);
-        card.append(title, projectLine, preview, tagField, hint, error, actionsRow);
+        card.append(title, projectField, preview, tagField, hint, error, actionsRow);
         overlay.append(card);
         root.append(overlay);
         tagInput.focus();
 
-        fetchExistingTags(project).then((tags) => {
+        fetchExistingTags(projectInput.value.trim()).then((tags) => {
             knownTags = tags;
             if (!tagMenu.hidden) renderTagMenu(tagInput.value);
         });
@@ -1049,7 +1072,14 @@ function mount(node) {
         });
         saveButton.addEventListener("click", async () => {
             const tag = tagInput.value.trim();
+            const targetProject = projectInput.value.trim();
             error.hidden = true;
+            if (!targetProject) {
+                error.textContent = "Carousel project cannot be blank.";
+                error.hidden = false;
+                projectInput.focus();
+                return;
+            }
             saveButton.disabled = true;
             cancelButton.disabled = true;
             saveButton.textContent = "Saving…";
@@ -1059,7 +1089,7 @@ function mount(node) {
                         method: "POST",
                         headers: {"Content-Type": "application/json"},
                         body: JSON.stringify({
-                            project,
+                            project: targetProject,
                             filename: item.filename,
                             subfolder: item.subfolder ?? "",
                             type: item.type ?? "output",
@@ -1071,7 +1101,7 @@ function mount(node) {
                 const body = await response.json();
                 if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
                 captureStatus.textContent =
-                    `Saved @${body.asset?.tag ?? tag} to the ${project} Asset Carousel.`;
+                    `Saved @${body.asset?.tag ?? tag} to the ${targetProject} Asset Carousel.`;
                 overlay.remove();
             } catch (captureError) {
                 error.textContent = captureError.message || String(captureError);

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -190,7 +190,7 @@ function injectStyles() {
         .h3r-badge { color:#d5d9e3; opacity:.75; }
         .h3r-video-panel { width:100%; height:300px; min-height:140px; max-height:1200px;
             flex:0 0 auto; display:flex; flex-direction:column; overflow:hidden;
-            border:1px solid #343b4b; border-radius:6px; background:#08090c; }
+            position:relative; border:1px solid #343b4b; border-radius:6px; background:#08090c; }
         .h3r-video { width:100%; height:calc(100% - 11px); min-height:0; display:block;
             flex:1 1 auto; background:#08090c; object-fit:contain; }
         .h3r-video-grip { height:11px; flex:0 0 11px; cursor:ns-resize;
@@ -200,6 +200,27 @@ function injectStyles() {
             width:40px; height:2px; border-top:1px solid #7e899f;
             border-bottom:1px solid #4f586b; }
         .h3r-video-grip:hover { background:linear-gradient(180deg,#313848,#1d212b); }
+        .h3r-capture-row { display:flex; align-items:center; gap:7px; }
+        .h3r-capture-button { flex:0 0 auto; padding:6px 10px; border:1px solid #63708b;
+            border-radius:5px; background:#232837; color:#eef1f7; cursor:pointer; }
+        .h3r-capture-button:hover { background:#343b4b; }
+        .h3r-capture-button:disabled { opacity:.42; cursor:not-allowed; }
+        .h3r-capture-status { color:#aeb5c5; opacity:.8; overflow:hidden;
+            text-overflow:ellipsis; white-space:nowrap; }
+        .h3r-capture-dialog { position:absolute; inset:0; z-index:20; display:flex;
+            align-items:center; justify-content:center; background:rgba(6,7,10,.72); }
+        .h3r-capture-card { display:flex; flex-direction:column; gap:9px; width:min(320px, 92%);
+            padding:12px; border:1px solid #56637e; border-radius:8px; background:#181c26;
+            box-shadow:0 8px 28px rgba(0,0,0,.5); }
+        .h3r-capture-preview { width:100%; max-height:180px; object-fit:contain;
+            border:1px solid #343b4b; border-radius:6px; background:#08090c; }
+        .h3r-capture-title { font-weight:700; color:#a9c2ff; }
+        .h3r-capture-field { display:flex; flex-direction:column; gap:4px; color:#aeb5c5; }
+        .h3r-capture-tag { width:100%; padding:6px 7px; border:1px solid #56637e;
+            border-radius:5px; background:#101218; color:#eef1f7; }
+        .h3r-capture-hint { color:#8b93a6; font-size:11px; }
+        .h3r-capture-error { color:#ff9a9a; }
+        .h3r-capture-actions { display:flex; justify-content:flex-end; gap:7px; }
         .h3r-label { display:flex; flex-direction:column; gap:4px; color:#aeb5c5; }
         .h3r-prompt { width:100%; min-height:120px; resize:vertical; padding:7px;
             border:1px solid #56637e; border-radius:5px; background:#101218; color:#eef1f7; }
@@ -845,6 +866,157 @@ function mount(node) {
         setVideoHeight(DEFAULT_VIDEO_HEIGHT, true);
     });
 
+    const captureRow = document.createElement("div");
+    captureRow.className = "h3r-capture-row";
+    const captureButton = document.createElement("button");
+    captureButton.type = "button";
+    captureButton.className = "h3r-capture-button";
+    captureButton.textContent = "Capture frame…";
+    captureButton.title = "Scrub the preview above to the desired frame, then save it as a project asset in the Asset Carousel.";
+    const captureStatus = document.createElement("span");
+    captureStatus.className = "h3r-capture-status";
+    captureRow.append(captureButton, captureStatus);
+
+    function captureTargetProject() {
+        return planResumeContext(node).runName;
+    }
+
+    async function fetchExistingTags(project) {
+        try {
+            const response = await api.fetchApi(
+                `/minimax_h3_context_loop/project-assets?${new URLSearchParams({project})}`);
+            const catalog = await response.json();
+            if (!response.ok) throw new Error(catalog.error || `HTTP ${response.status}`);
+            return (catalog.assets ?? [])
+                .map((item) => String(item.tag || "").trim())
+                .filter(Boolean);
+        } catch (_error) {
+            return [];
+        }
+    }
+
+    function closeCaptureDialog() {
+        videoPanel.querySelector(".h3r-capture-dialog")?.remove();
+        video.pause();
+    }
+
+    async function openCaptureDialog() {
+        const item = video.h3CaptureItem;
+        if (!item?.filename) {
+            captureStatus.textContent = "No saved preview to capture from yet.";
+            return;
+        }
+        video.pause();
+        const captureTime = video.currentTime;
+        let project = "";
+        try {
+            project = captureTargetProject();
+        } catch (_error) {
+            captureStatus.textContent = "Open a connected Plan to name the target project.";
+            return;
+        }
+        closeCaptureDialog();
+
+        const canvas = document.createElement("canvas");
+        canvas.width = video.videoWidth || 640;
+        canvas.height = video.videoHeight || 360;
+        const context2d = canvas.getContext("2d");
+        try { context2d?.drawImage(video, 0, 0, canvas.width, canvas.height); }
+        catch (_error) { /* tainted or unavailable frame; dialog still works */ }
+
+        const overlay = document.createElement("div");
+        overlay.className = "h3r-capture-dialog";
+        const card = document.createElement("div");
+        card.className = "h3r-capture-card";
+        const title = document.createElement("div");
+        title.className = "h3r-capture-title";
+        title.textContent = `Save frame at ${captureTime.toFixed(2)}s`;
+        const preview = document.createElement("img");
+        preview.className = "h3r-capture-preview";
+        try { preview.src = canvas.toDataURL("image/png"); } catch (_error) {}
+        const tagField = document.createElement("label");
+        tagField.className = "h3r-capture-field";
+        tagField.append("Tag");
+        const tagInput = document.createElement("input");
+        tagInput.className = "h3r-capture-tag";
+        tagInput.placeholder = "e.g. hero_pose";
+        tagInput.setAttribute("list", "h3r-capture-tag-options");
+        const tagOptions = document.createElement("datalist");
+        tagOptions.id = "h3r-capture-tag-options";
+        tagField.append(tagInput, tagOptions);
+        const hint = document.createElement("div");
+        hint.className = "h3r-capture-hint";
+        hint.textContent = "Pick an existing tag to save this as an updated take — " +
+            "a number is appended automatically (e.g. hero_pose_2) so both stay in the Carousel.";
+        const error = document.createElement("div");
+        error.className = "h3r-capture-error";
+        error.hidden = true;
+        const actionsRow = document.createElement("div");
+        actionsRow.className = "h3r-capture-actions";
+        const cancelButton = document.createElement("button");
+        cancelButton.type = "button";
+        cancelButton.className = "h3r-button";
+        cancelButton.textContent = "Cancel";
+        const saveButton = document.createElement("button");
+        saveButton.type = "button";
+        saveButton.className = "h3r-button";
+        saveButton.textContent = "Save to Carousel";
+        actionsRow.append(cancelButton, saveButton);
+        card.append(title, preview, tagField, hint, error, actionsRow);
+        overlay.append(card);
+        videoPanel.append(overlay);
+        tagInput.focus();
+
+        fetchExistingTags(project).then((tags) => {
+            tagOptions.replaceChildren(...tags.map((tag) => {
+                const option = document.createElement("option");
+                option.value = tag;
+                return option;
+            }));
+        });
+
+        cancelButton.addEventListener("click", () => overlay.remove());
+        overlay.addEventListener("click", (event) => {
+            if (event.target === overlay) overlay.remove();
+        });
+        saveButton.addEventListener("click", async () => {
+            const tag = tagInput.value.trim();
+            error.hidden = true;
+            saveButton.disabled = true;
+            cancelButton.disabled = true;
+            saveButton.textContent = "Saving…";
+            try {
+                const response = await api.fetchApi(
+                    "/minimax_h3_context_loop/project-assets/capture-frame", {
+                        method: "POST",
+                        headers: {"Content-Type": "application/json"},
+                        body: JSON.stringify({
+                            project,
+                            filename: item.filename,
+                            subfolder: item.subfolder ?? "",
+                            type: item.type ?? "output",
+                            time_seconds: captureTime,
+                            tag,
+                        }),
+                    },
+                );
+                const body = await response.json();
+                if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+                captureStatus.textContent =
+                    `Saved @${body.asset?.tag ?? tag} to the ${project} Asset Carousel.`;
+                overlay.remove();
+            } catch (captureError) {
+                error.textContent = captureError.message || String(captureError);
+                error.hidden = false;
+                saveButton.disabled = false;
+                cancelButton.disabled = false;
+                saveButton.textContent = "Save to Carousel";
+            }
+        });
+    }
+
+    captureButton.addEventListener("click", () => { void openCaptureDialog(); });
+
     const prefix = document.createElement("pre");
     prefix.className = "h3r-prefix";
     prefix.hidden = true;
@@ -1050,7 +1222,7 @@ function mount(node) {
     resume.append(resumeTitle, resumeRow, resumeStatus, revisionsPanel);
 
     root.append(
-        head, videoPanel, prefix, promptNotice, promptLabel,
+        head, videoPanel, captureRow, prefix, promptNotice, promptLabel,
         seedRow, candidateRow, actions, status, resume,
     );
 
@@ -1075,6 +1247,7 @@ function mount(node) {
         const resumePlayback = preservePosition && !video.paused;
         const revision = ++previewLoadRevision;
         video.dataset.source = source;
+        video.h3CaptureItem = item;
         video.src = source;
         video.load();
         if (preservePosition) {

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -181,8 +181,9 @@ function injectStyles() {
     style.id = "h3-chain-review-style";
     style.textContent = `
         .h3r-root { box-sizing:border-box; display:flex; flex-direction:column; gap:8px;
-            min-height:500px; padding:9px; overflow:auto; border:1px solid #56637e;
-            border-radius:8px; background:#181a20; color:#e8eaf0; font:12px/1.35 system-ui,sans-serif; }
+            min-height:500px; padding:9px; overflow:auto; position:relative;
+            border:1px solid #56637e; border-radius:8px; background:#181a20;
+            color:#e8eaf0; font:12px/1.35 system-ui,sans-serif; }
         .h3r-root * { box-sizing:border-box; }
         .h3r-root [hidden] { display:none !important; }
         .h3r-head { display:flex; align-items:center; justify-content:space-between; gap:8px; }
@@ -190,7 +191,7 @@ function injectStyles() {
         .h3r-badge { color:#d5d9e3; opacity:.75; }
         .h3r-video-panel { width:100%; height:300px; min-height:140px; max-height:1200px;
             flex:0 0 auto; display:flex; flex-direction:column; overflow:hidden;
-            position:relative; border:1px solid #343b4b; border-radius:6px; background:#08090c; }
+            border:1px solid #343b4b; border-radius:6px; background:#08090c; }
         .h3r-video { width:100%; height:calc(100% - 11px); min-height:0; display:block;
             flex:1 1 auto; background:#08090c; object-fit:contain; }
         .h3r-video-grip { height:11px; flex:0 0 11px; cursor:ns-resize;
@@ -207,11 +208,11 @@ function injectStyles() {
         .h3r-capture-button:disabled { opacity:.42; cursor:not-allowed; }
         .h3r-capture-status { color:#aeb5c5; opacity:.8; overflow:hidden;
             text-overflow:ellipsis; white-space:nowrap; }
-        .h3r-capture-dialog { position:absolute; inset:0; z-index:20; display:flex;
+        .h3r-capture-dialog { position:absolute; inset:0; z-index:30; display:flex;
             align-items:center; justify-content:center; background:rgba(6,7,10,.72); }
         .h3r-capture-card { display:flex; flex-direction:column; gap:9px; width:min(320px, 92%);
-            padding:12px; border:1px solid #56637e; border-radius:8px; background:#181c26;
-            box-shadow:0 8px 28px rgba(0,0,0,.5); }
+            max-height:90%; overflow-y:auto; padding:12px; border:1px solid #56637e;
+            border-radius:8px; background:#181c26; box-shadow:0 8px 28px rgba(0,0,0,.5); }
         .h3r-capture-preview { width:100%; max-height:180px; object-fit:contain;
             border:1px solid #343b4b; border-radius:6px; background:#08090c; }
         .h3r-capture-title { font-weight:700; color:#a9c2ff; }
@@ -896,7 +897,7 @@ function mount(node) {
     }
 
     function closeCaptureDialog() {
-        videoPanel.querySelector(".h3r-capture-dialog")?.remove();
+        root.querySelector(".h3r-capture-dialog")?.remove();
         video.pause();
     }
 
@@ -964,7 +965,7 @@ function mount(node) {
         actionsRow.append(cancelButton, saveButton);
         card.append(title, preview, tagField, hint, error, actionsRow);
         overlay.append(card);
-        videoPanel.append(overlay);
+        root.append(overlay);
         tagInput.focus();
 
         fetchExistingTags(project).then((tags) => {

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -891,13 +891,16 @@ function mount(node) {
     captureStatus.className = "h3r-capture-status";
     captureRow.append(captureButton, captureStatus);
 
+    function findAssetCarouselNode() {
+        return findUpstreamNode(node, ASSET_CAROUSEL_NAMES) ??
+            allNodes(app.graph).find((item) => ASSET_CAROUSEL_NAMES.has(nodeType(item)));
+    }
+
     function captureTargetProject() {
         // The Asset Carousel's project can be renamed independently of any
         // upstream Plan's run_name, so prefer reading it directly from a
         // connected (or any on-canvas) Carousel node before falling back.
-        const carouselNode = findUpstreamNode(node, ASSET_CAROUSEL_NAMES) ??
-            allNodes(app.graph).find((item) => ASSET_CAROUSEL_NAMES.has(nodeType(item)));
-        const carouselProject = carouselNode?._h3ProjectAssetCurrentProject?.();
+        const carouselProject = findAssetCarouselNode()?._h3ProjectAssetCurrentProject?.();
         if (carouselProject) return carouselProject;
         return planResumeContext(node).runName;
     }
@@ -1102,6 +1105,10 @@ function mount(node) {
                 if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
                 captureStatus.textContent =
                     `Saved @${body.asset?.tag ?? tag} to the ${targetProject} Asset Carousel.`;
+                const carouselNode = findAssetCarouselNode();
+                if (carouselNode?._h3ProjectAssetCurrentProject?.() === targetProject) {
+                    carouselNode._h3ProjectAssetRefresh?.();
+                }
                 overlay.remove();
             } catch (captureError) {
                 error.textContent = captureError.message || String(captureError);

--- a/web/h3_project_asset_manager.js
+++ b/web/h3_project_asset_manager.js
@@ -418,6 +418,10 @@ function mount(node) {
         previewMode: previewSelect.value === "full" ? "full" : "light",
     };
     const project = () => String(runNameInput.value || "").trim();
+    // Public accessor so other H3 node widgets (Review Gate's frame
+    // capture) can target the Carousel's actual current project, which can
+    // be renamed independently of any upstream Plan's run_name.
+    node._h3ProjectAssetCurrentProject = project;
     // Tokens distinguish A -> B -> A from an uninterrupted operation on A.
     let projectEpoch = 0;
     let projectDisposed = false;


### PR DESCRIPTION
## Summary
- Adds a "Capture frame..." control to the Review Gate's video preview: scrub to a frame, pick or type a tag, and save it straight into the Project Asset Carousel as a new image asset.
- Reusing an existing tag (e.g. `char-sammy`) saves the capture as an updated take with a bare incrementing suffix (`char-sammy1`, `char-sammy2`, ...) instead of colliding, so both stay visible in the Carousel.
- The capture dialog auto-detects the Carousel's actual current project (which can differ from an upstream Plan's `run_name`) via a small new accessor on the Carousel node, and lets you override it by hand if needed.
- The Carousel refreshes itself automatically after a successful capture when it's showing the target project, so the new asset shows up without a manual node/page refresh.

## Implementation
- Backend: new `POST /minimax_h3_context_loop/project-assets/capture-frame` route (`chain_nodes.py`). Extracts a single frame with ffmpeg using the same `-ss`/`-frames:v` pattern as the existing Plan Studio checkpoint-thumbnail builder, then imports it through the existing `ProjectAssetStore.import_file()` path (same as uploads/imports).
- `project_assets.py`: new `_capture_family_tag()` / `ProjectAssetStore.resolve_capture_tag()` for the bare-suffix "updated take" numbering, kept separate from the store's existing `_unique_tag()` (which other flows still use with `_2`, `_3`, ... suffixes) so nothing else in the tagging behavior changes.
- Frontend (`web/h3_chain_review_final.js`): "Capture frame..." button and a small dialog (frame preview, editable Carousel-project field, tag field with a custom dropdown of existing tags). `web/h3_project_asset_manager.js` gained a one-line `node._h3ProjectAssetCurrentProject` accessor so Review Gate can read the Carousel's real project instead of guessing from the Plan.

## Test plan
- [x] Verified the tag-family numbering logic (`_capture_family_tag`) directly in the project's venv (first reuse -> `1`, next -> `2`, re-capturing off an already-numbered tag -> next in the family).
- [x] Exercised the full flow live in ComfyUI: captured a frame from a saved Review Gate segment, picked an existing tag, confirmed it landed in the Asset Carousel under the correct project with the expected incrementing tag, and confirmed the Carousel auto-refreshes.
- [ ] Not tested: multiple simultaneous Review Gate / Carousel node pairs on one canvas (single-canvas, single-pair testing only so far).