### PR TITLE
Feature/asset carousel role help

### DIFF
--- a/docs/PROJECT_ASSETS.md
+++ b/docs/PROJECT_ASSETS.md
@@ -45,12 +45,14 @@ source project is not changed.
 
 ## Assign a role
 
-| Role | What it does |
-|---|---|
-| Native tagged reference | Makes the asset available to prompt-selected `@tag` references. |
-| Semantic picture | Makes a picture available as a `#tag` presentation anchor. |
-| Source track | Supplies the project's recoverable source video/audio timeline. |
-| Unassigned | Keeps the card visible without using an H3 reference slot or changing the generation fingerprint. |
+| Role | What it does | Use it for |
+|---|---|---|
+| Picture reference | Makes a picture available to prompt-selected `@tag` references. | An appearance/identity photo the model should reuse. |
+| Semantic anchor | Makes a picture available as a `#tag` presentation anchor. | A composition or layout guide, not a literal appearance to copy. |
+| Video reference | Gives the model the whole clip as a native `<Video N>` reference — identity, wardrobe, setting, lighting, and composition included. Activates only in scenes whose prompt includes the asset's tag. | You want the generated scene to *look like* the reference, not just move like it. |
+| Motion reference | Extracts only the pose, action, and motion timing from the clip and transfers it onto a named `<Subject N>` (set in **Target Subject**); the clip is downsampled (**Reference short edge**) specifically to suppress its own appearance from leaking through. | You want a character to *move* the way the reference moves, without copying who or what is actually in it. |
+| Source track | Not activated by any scene prompt. Supplies the project's recoverable Source Timeline — an exact prerecorded video or audio track (e.g. dialogue, or footage that must stay unaltered) that Chain Policy's Source reference / Final audio settings decide how to use. Only one Source track may be enabled per project. | A fixed track scenes are generated against, not a look or motion to imitate. |
+| Unassigned | Keeps the card visible without using an H3 reference slot or changing the generation fingerprint. | Staging a file before deciding its role, or archiving it from active use. |
 
 When you connect an existing `tagged_references` line, the Carousel creates
 Unassigned cards for its tags and media roles. Bind each card to an input file,
@@ -59,6 +61,16 @@ generation. Move other server media into the configured ComfyUI input folder
 first; browser requests cannot import arbitrary filesystem paths.
 
 Only references used by the current scene are decoded during sampling.
+
+### Timeline mode (Video reference and Motion reference)
+
+Both roles expose a **Timeline mode** control that decides which part of the
+reference clip a scene sees:
+
+| Mode | What it does | Use it for |
+|---|---|---|
+| Restart each scene (default) | Every scene that activates this reference starts playback at frame 0 of the clip, so every activation looks identical. Never requires any particular clip length. | A short loop, or any appearance/motion reference that should stay the same across the whole run. |
+| Sequential | Plays the reference forward continuously in lockstep with the Plan, starting from the first scene that activates it — later scenes see later parts of the clip. The clip must be at least as long as everything generated from that point on, or generation stops with an error telling you to shorten the Plan, supply a longer reference, or switch back to Restart each scene. | The reference is itself a continuous performance or source that should be walked through scene by scene, in step with the generated video. |
 
 ## Group a song and its stems
 

--- a/web/h3_project_asset_manager.js
+++ b/web/h3_project_asset_manager.js
@@ -36,6 +36,41 @@ const ROLE_LABELS = {
     audio_reference: "tagged audio reference",
     source_track: "source track",
 };
+const VIDEO_ROLE_HELP = {
+    video: "Gives the model the whole clip to see and reuse: identity, "
+        + "wardrobe, setting, lighting, and composition. Only activates in a "
+        + "scene when that scene's prompt includes this asset's tag. Pick "
+        + "this when you want the generated scene to look like the "
+        + "reference, not just move like it.",
+    motion: "Extracts only the pose, action, and motion timing from this "
+        + "clip and transfers it onto the Target Subject named below - the "
+        + "source's own appearance is deliberately suppressed (see "
+        + "Reference short edge). Pick this when you want a character to "
+        + "move the way the reference moves without copying who or what is "
+        + "in it.",
+    source_track: "Not activated by any scene prompt - only one may be "
+        + "enabled per project. This becomes the project's exact Source "
+        + "Timeline (a prerecorded video or audio track, such as dialogue "
+        + "or footage, that must stay unaltered) which Chain Policy's "
+        + "Source reference / Final audio settings decide how to use. Pick "
+        + "this for a fixed track scenes are generated against, not a "
+        + "look or motion to imitate.",
+};
+const TIMELINE_MODE_HELP = {
+    restart_each_scene: "Every scene that uses this reference starts "
+        + "playback at frame 0 of the clip, so every activation looks "
+        + "identical. Use this for a short loop or an appearance/motion "
+        + "reference that should not change across the run - it never "
+        + "requires the clip to be any particular length.",
+    sequential: "Plays the reference forward continuously in lockstep with "
+        + "the Plan, starting from the first scene that activates it, so "
+        + "later scenes see later parts of the clip. The clip must be at "
+        + "least as long as everything generated from that point on, or "
+        + "generation stops with an error telling you to shorten the Plan, "
+        + "supply a longer reference, or switch back to Restart each "
+        + "scene. Use this when the reference is itself a continuous "
+        + "performance or source to walk through scene by scene.",
+};
 
 function displayRole(role) {
     return ROLE_LABELS[role] ?? String(role || "").replaceAll("_", " ");
@@ -1442,8 +1477,17 @@ function mount(node) {
                 const option = el("option", "", displayRole(value));
                 option.value = value; option.selected = value === asset.role; role.append(option);
             }
-            role.addEventListener("change", () => updateAsset(asset, {role: role.value}));
+            if (asset.kind === "video" && VIDEO_ROLE_HELP[asset.role]) {
+                role.title = VIDEO_ROLE_HELP[asset.role];
+            }
+            role.addEventListener("change", () => {
+                if (VIDEO_ROLE_HELP[role.value]) role.title = VIDEO_ROLE_HELP[role.value];
+                updateAsset(asset, {role: role.value});
+            });
             roleLabel.append(role); editor.append(roleLabel);
+            if (asset.kind === "video" && VIDEO_ROLE_HELP[asset.role]) {
+                editor.append(el("small", "h3pa-status", VIDEO_ROLE_HELP[asset.role]));
+            }
         }
         if (isAudio && isSourceTrack) {
             const tracks = el("div", "h3pa-audio-tracks");
@@ -1556,8 +1600,16 @@ function mount(node) {
                 option.value = value; option.selected = value === (asset.options?.timeline_mode ?? "restart_each_scene");
                 timeline.append(option);
             }
-            timeline.addEventListener("change", () => updateAsset(asset, {options: {timeline_mode: timeline.value}}));
+            const timelineHelp = el("small", "h3pa-status",
+                TIMELINE_MODE_HELP[asset.options?.timeline_mode ?? "restart_each_scene"]);
+            timeline.title = TIMELINE_MODE_HELP[asset.options?.timeline_mode ?? "restart_each_scene"];
+            timeline.addEventListener("change", () => {
+                timeline.title = TIMELINE_MODE_HELP[timeline.value];
+                timelineHelp.textContent = TIMELINE_MODE_HELP[timeline.value];
+                updateAsset(asset, {options: {timeline_mode: timeline.value}});
+            });
             timelineLabel.append(timeline); editor.append(timelineLabel);
+            editor.append(timelineHelp);
             if (asset.metadata?.has_audio) {
                 const pairedLabel = el("label");
                 const paired = el("input"); paired.type = "checkbox";

--- a/web/h3_project_asset_manager.js
+++ b/web/h3_project_asset_manager.js
@@ -213,6 +213,7 @@ function injectStyles() {
         .h3pa-button{padding:6px 9px;border:1px solid var(--h3pa-border);border-radius:6px;
           background:var(--h3pa-panel);color:var(--h3pa-text);cursor:pointer}.h3pa-button:hover{border-color:var(--h3pa-accent)}
         .h3pa-status{min-height:18px;color:var(--h3pa-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+        .h3pa-help{display:block;color:var(--h3pa-muted);white-space:normal;line-height:1.35}
         .h3pa-tabs{display:flex;gap:5px;overflow-x:auto;align-items:center;flex:0 0 auto}.h3pa-tab.active{background:var(--h3pa-selected);border-color:var(--h3pa-accent)}
         .h3pa-folder-tools{display:flex;gap:5px;align-items:center;margin-left:auto;padding-left:7px;border-left:1px solid var(--h3pa-border);flex:0 0 auto}.h3pa-folder-tools select{max-width:190px;min-width:110px;padding:6px 8px;border:1px solid var(--h3pa-border);border-radius:6px;background:var(--h3pa-panel);color:var(--h3pa-text)}
         .h3pa-stage{flex:1 1 auto;min-height:230px;display:grid;grid-template-columns:minmax(0,1fr) 260px;gap:10px;overflow:hidden}
@@ -1486,7 +1487,7 @@ function mount(node) {
             });
             roleLabel.append(role); editor.append(roleLabel);
             if (asset.kind === "video" && VIDEO_ROLE_HELP[asset.role]) {
-                editor.append(el("small", "h3pa-status", VIDEO_ROLE_HELP[asset.role]));
+                editor.append(el("small", "h3pa-help", VIDEO_ROLE_HELP[asset.role]));
             }
         }
         if (isAudio && isSourceTrack) {
@@ -1600,7 +1601,7 @@ function mount(node) {
                 option.value = value; option.selected = value === (asset.options?.timeline_mode ?? "restart_each_scene");
                 timeline.append(option);
             }
-            const timelineHelp = el("small", "h3pa-status",
+            const timelineHelp = el("small", "h3pa-help",
                 TIMELINE_MODE_HELP[asset.options?.timeline_mode ?? "restart_each_scene"]);
             timeline.title = TIMELINE_MODE_HELP[asset.options?.timeline_mode ?? "restart_each_scene"];
             timeline.addEventListener("change", () => {


### PR DESCRIPTION
Adds in-UI help text/tooltips explaining the Project Asset Carousel's video
"Asset use" roles and its Timeline mode setting, which were previously
undocumented anywhere.

- "Asset use" roles: video reference (feeds a native `<Video N>` visual
  reference), motion reference (transfers only pose/action onto a
  `<Subject N>` while suppressing source appearance), and source track
  (becomes the project's exact Source Timeline, never prompt-activated).
- Timeline mode: `restart_each_scene` always starts at frame 0;
  `sequential` advances the reference in lockstep with the Plan and
  requires a long-enough clip.
- Expands `docs/PROJECT_ASSETS.md` to match the new in-UI text.
- Fixes the new help text getting clipped to one line inside the video
  panel (it was reusing a `nowrap`+ellipsis status class meant for
  short one-line status text).

## Commits
- Explain Asset Carousel roles and Timeline mode in the UI and docs
- Stop clipping the Asset use / Timeline mode help text