### PR TITLE
Expose native Studio branch commands for companion applications

### DIFF
--- a/docs/WORKING_BRANCHES.md
+++ b/docs/WORKING_BRANCHES.md
@@ -6,6 +6,23 @@ It does not have to become the project default before generation or upscaling.
 
 ## Plan Studio
 
+Mounted Studios expose a versioned browser interface, `node._h3BranchCommands`,
+for companion applications. Its `snapshot()` returns branch labels, revision,
+save/recovery status and pending operation identity without authoring bodies.
+`command(action, options, expected, assertCurrent)` delegates to this Studio's
+existing controller for save, switch, create, refresh, reload, restore-draft,
+retry and default actions. Pass the snapshot's `run_name`, `selected` and
+`revision` as `expected`; an optional attachment guard is checked at native
+continuation boundaries. The interface's `owner` is the current authoring Plan
+node. It is removed when the Studio is removed.
+
+The caller must keep unapplied companion drafts separate and check its queue
+and workflow binding. Current branch restoration needs a direct Plan JSON
+widget; connected text sources remain unavailable. Native ownership checks,
+revision conflicts, recovery drafts and exact pending-operation retries still
+belong to Studio. A returned `warning` means the action needs review, even if
+an earlier save or branch creation already reached the server.
+
 - Use the arrows or branch dropdown to change the Plan and clips shown in Studio.
 - **Fork here** retains the selected branch's saved scenes through the current
   scene. The whole authored Plan remains available for continuing or editing.

--- a/tests/_branch_commands_js_test.mjs
+++ b/tests/_branch_commands_js_test.mjs
@@ -1,0 +1,81 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {StudioBranches, BranchDrafts} from '../web/h3_working_branches.mjs';
+import {studioBranchCommands} from '../web/h3_branch_commands.mjs';
+
+async function fixture() {
+    let authoring = {plan_json:JSON.stringify({shots:[{id:'one',prompt:'first',seed:'18446744073709551615'}]})};
+    const writes = [], values = new Map(), records = new Map([
+        ['main',{id:'main',name:'Original',revision:'1',authoring:structuredClone(authoring)}],
+        ['a'.repeat(32),{id:'a'.repeat(32),name:'Second',revision:'2',authoring:{plan_json:JSON.stringify({shots:[{id:'one',prompt:'second',seed:'1'}]})}}],
+    ]);
+    const controller = new StudioBranches({capture:() => structuredClone(authoring), apply:async record => { authoring = structuredClone(record.authoring); },
+        drafts:new BranchDrafts({getItem:key => values.get(key) ?? null,setItem:(key,value) => values.set(key,value),removeItem:key => values.delete(key)},'test'),
+        changed(){}, flush:async () => {}, request:async body => {
+            if (body.action === 'list') return {branches:[...records.values()],default_branch:'main'};
+            if (body.action === 'load') return structuredClone(records.get(body.branch_id));
+            writes.push(body);
+            if (body.action === 'save' && records.get(body.branch_id).revision !== body.revision) throw Object.assign(Error('Stale saved branch'),{status:400});
+            const id = body.action === 'create' ? body.operation_id : body.branch_id;
+            const record = {id,name:body.name || records.get(id)?.name,revision:String(writes.length+2),authoring:body.authoring};
+            records.set(id,structuredClone(record)); return record;
+        }});
+    const owner = {}, bridge = studioBranchCommands(controller,{owner:() => owner});
+    await controller.refresh('film'); controller.observe();
+    return {controller,bridge,owner,writes,records,values,edit:() => {authoring.plan_json=authoring.plan_json.replace('first','edited');controller.observe();},capture:() => authoring};
+}
+
+test('snapshot is detached and exposes status without prompt or recovery bodies',async () => {
+    const f = await fixture(), state = f.bridge.snapshot();
+    assert.equal(f.bridge.owner,f.owner); assert.equal(state.dirty,false);
+    assert.equal(JSON.stringify(state).includes('plan_json'),false);
+    state.branches[0].name='changed'; assert.equal(f.bridge.snapshot().branches[0].name,'Original');
+    f.edit(); assert.equal(f.bridge.snapshot().dirty,true);
+    assert.ok(f.bridge.snapshot().revision > state.revision);
+});
+test('save and switch use native saves, preserve exact seeds, and apply the saved branch',async () => {
+    const f = await fixture(); f.edit();
+    const result = await f.bridge.command('switch',{target:'a'.repeat(32)},f.bridge.snapshot());
+    assert.equal(result.warning,undefined); assert.equal(result.state.busy,false);
+    assert.equal(result.state.selected,'a'.repeat(32));
+    assert.equal(JSON.parse(f.writes[0].authoring.plan_json).shots[0].seed,'18446744073709551615');
+    assert.equal(JSON.parse(f.capture().plan_json).shots[0].prompt,'second');
+});
+test('navigation without saving keeps the native recovery draft',async () => {
+    const f = await fixture(); f.edit();
+    await f.bridge.command('switch',{target:'a'.repeat(32),save:false},f.bridge.snapshot());
+    assert.equal(f.writes.length,0);
+    assert.match(f.controller.drafts.read('film','main').authoring.plan_json,/edited/);
+});
+test('stale views, busy native operations and unsupported actions never write',async () => {
+    const f = await fixture(), old=f.bridge.snapshot(); f.edit();
+    await assert.rejects(f.bridge.command('save',{},old),/state changed/);
+    f.controller.busy=true;
+    await assert.rejects(f.bridge.command('save',{},f.bridge.snapshot()),/in progress/);
+    f.controller.busy=false;
+    await assert.rejects(f.bridge.command('erase',{},f.bridge.snapshot()),/Unsupported/);
+    assert.equal(f.writes.length,0);
+});
+test('attachment loss after flush cannot save or apply a new branch',async () => {
+    const f = await fixture(); let attached=true;
+    f.controller.flush=async () => { attached=false; };
+    await assert.rejects(f.bridge.command('switch',{target:'a'.repeat(32)},f.bridge.snapshot(),() => {if(!attached)throw Error('Detached');}),/Detached/);
+    assert.equal(f.writes.length,0); assert.equal(f.controller.selected,'main');
+    assert.equal(f.bridge.snapshot().busy,false);
+});
+test('stale server save produces a warning and leaves the current Plan intact',async () => {
+    const f=await fixture(); f.records.get('main').revision='remote';
+    const result=await f.bridge.command('switch',{target:'a'.repeat(32)},f.bridge.snapshot());
+    assert.match(result.warning,/Stale/); assert.equal(result.state.selected,'main');
+});
+test('create and uncertain retry retain the native operation ID',async () => {
+    const f=await fixture(), request=f.controller.request; let fail=true;
+    f.controller.request=async body => { if(body.action==='create' && fail)throw Error('Network gone');return request(body); };
+    const result=await f.bridge.command('create',{name:'New'},f.bridge.snapshot());
+    assert.match(result.warning,/uncertain/); const pending=f.bridge.snapshot().pending;
+    assert.equal(pending.action,'create'); assert.equal(JSON.stringify(pending).includes('plan_json'),false);
+    fail=false; await f.bridge.command('retry',{},f.bridge.snapshot());
+    assert.equal(f.writes.at(-1).operation_id,pending.operation_id);
+    assert.equal(f.bridge.snapshot().pending,null);
+    assert.ok(f.bridge.snapshot().branches.some(item => item.id===pending.operation_id));
+});

--- a/web/h3_branch_commands.mjs
+++ b/web/h3_branch_commands.mjs
@@ -1,0 +1,62 @@
+// A callable surface over the mounted Studio's existing controller. This does
+// not create another branch writer, draft store, or continuation scheduler.
+export function studioBranchCommands(branches, {owner, available = () => ""}) {
+    let busy = false, last = "", revision = 0;
+    function snapshot() {
+        const reason = available();
+        const pending = branches.pending ? Object.fromEntries(
+            ["action", "run_name", "branch_id", "operation_id"].map(key => [key, branches.pending[key]])) : null;
+        const state = {
+            version:1, run_name:branches.run, selected:branches.selected,
+            default_branch:branches.defaultBranch, ready:branches.ready,
+            busy:busy || branches.busy, available:!reason, reason,
+            saved_revision:branches.binding?.revision ?? "",
+            dirty:branches.observedSignature == null ? null : branches.observedSignature !== branches.savedSignature,
+            conflict:branches.conflict, error:branches.error,
+            draft_available:Boolean(branches.draftRecovery), draft_status:branches.draftStatus,
+            pending,
+            branches:branches.records.map(item => Object.fromEntries(
+                ["id", "name", "revision", "source_branch", "fork_scene", "created_at"].filter(key => key in item).map(key => [key, item[key]]))),
+        };
+        const serialized = JSON.stringify(state);
+        if (serialized !== last) { last = serialized; revision++; }
+        return {...state, revision};
+    }
+    async function command(action, args = {}, expected, assertCurrent = () => {}) {
+        const before = snapshot();
+        if (!before.available) throw new Error(before.reason);
+        if (before.busy) throw new Error("Another native branch action is in progress.");
+        if (!expected || expected.run_name !== before.run_name || expected.selected !== before.selected || expected.revision !== before.revision) {
+            throw new Error("Branch state changed. Refresh before continuing.");
+        }
+        const actions = {
+            refresh:() => branches.refresh(before.run_name),
+            save:() => branches.perform(async () => {}),
+            switch:() => branches.switchTo(args.target, {save:args.save !== false}),
+            create:() => branches.create(args.name, args.through_scene ?? 0, args.new_seeds === true),
+            reload:() => branches.reloadSaved(),
+            "restore-draft":() => branches.restoreDraft(),
+            retry:() => branches.retryPending(),
+            default:() => branches.makeDefault(),
+        };
+        if (!Object.hasOwn(actions, action)) throw new Error("Unsupported native branch action.");
+        if (action === "switch" && typeof args.target !== "string") throw new Error("Choose a target branch.");
+        if (action === "create" && (typeof args.name !== "string" || !args.name.trim() || args.name.trim().length > 120
+            || !Number.isInteger(args.through_scene ?? 0) || (args.through_scene ?? 0) < 0)) throw new Error("Choose a branch name and a valid fork scene.");
+        if (action === "retry" && !before.pending) throw new Error("There is no pending branch operation.");
+        if (action === "restore-draft" && !before.draft_available) throw new Error("There is no native recovery draft.");
+        assertCurrent();
+        busy = true;
+        const original = branches.isCurrent;
+        branches.isCurrent = (...values) => {
+            try { assertCurrent(); return original(...values); } catch { return false; }
+        };
+        try {
+            await actions[action]();
+            assertCurrent();
+            return {state:snapshot(), ...(branches.error ? {warning:branches.error} : {})};
+        } finally { branches.isCurrent = original; busy = false; }
+    }
+    return Object.freeze({version:1, get owner() { return owner(); }, snapshot,
+        async command(...args) { const result = await command(...args); return {...result, state:snapshot()}; }});
+}

--- a/web/h3_chain_plan_studio.js
+++ b/web/h3_chain_plan_studio.js
@@ -1,6 +1,7 @@
 import {app} from "/scripts/app.js";
 import {api} from "/scripts/api.js";
 import {StudioBranches, BranchDrafts, branchOperationId, branchWidgetTransaction, branchRequestPath, workingBranchId} from "./h3_working_branches.mjs?v=0.7.19";
+import {studioBranchCommands} from "./h3_branch_commands.mjs?v=1";
 import {branchPolicyNodes, captureBranchPolicyInputs, restoreBranchPolicyInputs} from "./h3_plan_restore_core.mjs?v=0.7.19";
 import {
     CONTINUATION_MODES,
@@ -856,6 +857,17 @@ function mount(node) {
                 throw error;
             }
             return data;
+        },
+    });
+
+    node._h3BranchCommands = studioBranchCommands(branches, {
+        owner:() => state.planOwner,
+        available:() => {
+            if (state.disposed || !state.planOwner || !state.plan || !branchWidget) return "Wait for a mounted Plan Studio with working-branch support.";
+            const owner = state.planOwner;
+            if (owner.inputs?.some(input => ["plan_json", "plan_json_input"].includes(input.name) && input.link != null)
+                || String(widget(owner, "plan_json_input")?.value ?? "").trim()) return "Native branch restoration requires a direct Plan JSON widget; connected Plan text is not supported yet.";
+            return "";
         },
     });
 
@@ -6611,6 +6623,7 @@ function mount(node) {
         delete node._h3PromptCompanionSetActiveScene;
         delete node._h3PromptCompanionSetScenePrompt;
         delete node._h3FlushProjectWrites;
+        delete node._h3BranchCommands;
         disposePlayer();
         void finalFlush.catch((error) => console.warn(
             "H3 Plan Studio could not flush project edits while closing:",


### PR DESCRIPTION
Plan Studio's branch controller is private to its UI, so companions cannot save or switch branches while retaining native recovery and pending-operation behavior.

Expose a versioned interface on mounted Studios that delegates to the existing controller. It provides status without prompt/recovery bodies, rejects stale command state, accepts an attachment guard at continuation boundaries, and is removed with the node. Connected Plan text remains unavailable because the native restoration path still targets the backing widget.

Validation: seven new interface tests plus existing working-branch, recovery, branch-switch and Plan Studio JavaScript suites pass. Node smoke, workflow catalog and v0.5/v0.4 contract scripts pass. The chain smoke script cannot start with the available local Python environment: `comfy_aimdo.malloc_graph` is missing. No production project or GPU job was used. SceneWeaver integration tests exercise the actual controller with synthetic Studio callbacks; live validation remains pending.
