### PR TITLE
Freeze saved-cut sources for companion delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ scene can be reviewed, retried, checkpointed, resumed, and assembled later.
   DeRoPE/upscale checkpoints and recoverable VIDEO PNG publication.
 - Provides scene review, alternate takes, branch management, final assembly,
   masked editing, and deferred upscaling.
+- Offers [saved delivery snapshots](docs/SAVED_DELIVERY.md) for companion tools:
+  assemble an exact saved cut and captions even after later editorial changes.
 - Captures a frame from a saved Review Gate preview into the Project Asset
   Carousel as a new tagged picture, without replacing the original take.
 

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -9606,7 +9606,7 @@ def _parse_timed_lyrics(value: Any) -> list[dict[str, Any]]:
 
 def _editorial_subtitle_cues(
         run_name: str, editorial: dict[str, Any], total_frames: int,
-        timeline_origin_frames: int = 0
+        timeline_origin_frames: int = 0, *, catalog: dict[str, Any] | None = None
         ) -> list[dict[str, Any]]:
     settings = editorial.get("subtitles") or {}
     if settings.get("mode") != "preview_srt":
@@ -9615,7 +9615,8 @@ def _editorial_subtitle_cues(
     if not asset_id:
         raise ValueError(
             "Editorial subtitles are enabled but no lyrics asset is selected.")
-    catalog = ProjectAssetStore(_input_root(), _output_root()).load(run_name)
+    if catalog is None:
+        catalog = ProjectAssetStore(_input_root(), _output_root()).load(run_name)
     asset = next((item for item in catalog.get("assets", [])
                   if str(item.get("id") or "") == asset_id), None)
     if asset is None or asset.get("kind") != "audio":

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -19179,6 +19179,27 @@ class MiniMaxH3ChainCheckpointManager:
         return (manifest,)
 
 
+class MiniMaxH3ChainDeliverySource:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"snapshot_json": ("STRING", {"default": "", "multiline": True,
+            "tooltip": "Exact saved source prepared by the H3 delivery snapshot API. Retains checkpoint lineage, final-cut settings and subtitles without following later edits."})}}
+
+    RETURN_TYPES = (MANIFEST_TYPE,)
+    RETURN_NAMES = ("saved_delivery_manifest",)
+    FUNCTION = "load"
+    CATEGORY = "conditioning/minimax/context_loop"
+    DESCRIPTION = "Load and verify a frozen saved delivery source without generating scenes or changing active checkpoints."
+
+    @classmethod
+    def IS_CHANGED(cls, *args, **kwargs):
+        return float("NaN")
+
+    def load(self, snapshot_json):
+        from .delivery_snapshot import load
+        return (load(sys.modules[__name__], snapshot_json),)
+
+
 class MiniMaxH3ChainFirstSceneImage:
     @classmethod
     def INPUT_TYPES(cls):
@@ -27555,6 +27576,8 @@ class MiniMaxH3ChainAssemble:
                 upscale_manifest)
             manifest = upscale_support._assembly_manifest(
                 upscale_manifest, upscale_segments)
+        if upscale_manifest is not None and manifest.get("delivery_pictures") is not None:
+            raise ValueError("Frozen saved-delivery pictures require a processed-source adapter before assembling an upscale manifest.")
         segments = _validate_manifest(manifest)
         geometry = common_saved_resolution(segments, "H3 Chain Assemble")
         if geometry:
@@ -27565,8 +27588,10 @@ class MiniMaxH3ChainAssemble:
         editorial = _manifest_editorial(manifest)
         editorial, editorial_records, editorial_extension_frames = (
             _editorial_timeline_records(run_name, segments, editorial))
-        presentation_segments = _editorial_presentation_segments(
-            run_name, segments, editorial)
+        from .delivery_snapshot import presentation_segments as frozen_presentation_segments
+        presentation_segments = frozen_presentation_segments(sys.modules[__name__], manifest)
+        if presentation_segments is None:
+            presentation_segments = _editorial_presentation_segments(run_name, segments, editorial)
         generated_extension_frames = int(manifest["total_delivered_frames"])
         editorial_used_frames = sum(
             int(item.get("frame_count", 0)) for item in editorial_records
@@ -27700,11 +27725,13 @@ class MiniMaxH3ChainAssemble:
         if generated_sidecar_audio is not None and prelude is not None:
             generated_sidecar_audio = _audio_with_prelude(
                 generated_sidecar_audio, extension_frames, prelude)
-        subtitle_cues = _editorial_subtitle_cues(
-            run_name, editorial, editorial_extension_frames,
-            timeline_origin_frames=int(
-                (manifest.get("chapter") or {}).get(
-                    "editorial_origin_frame", 0)))
+        from .delivery_snapshot import subtitle_cues as frozen_subtitle_cues
+        subtitle_origin = int((manifest.get("chapter") or {}).get("editorial_origin_frame", 0))
+        subtitle_cues = frozen_subtitle_cues(manifest, editorial_extension_frames, subtitle_origin)
+        if subtitle_cues is None:
+            subtitle_cues = _editorial_subtitle_cues(
+                run_name, editorial, editorial_extension_frames,
+                timeline_origin_frames=subtitle_origin)
         if prelude_frames and subtitle_cues:
             subtitle_shift = prelude_frames / float(FPS)
             subtitle_cues = [{
@@ -27942,6 +27969,20 @@ class MiniMaxH3ChainAssemble:
                 len(segments), int(upscale_manifest["clip_count"]))
         _LOG.info("H3 Chain %s", status)
         published_video = output_copy or final_path
+        if manifest.get("_delivery_snapshot_json"):
+            _atomic_json(os.path.splitext(final_path)[0] + ".delivery.json", {
+                "format": "h3_delivery_record_v1",
+                "snapshot_json": manifest["_delivery_snapshot_json"],
+                "snapshot_id": manifest["delivery_snapshot_id"],
+                "settings": {"audio_source": audio_source, "filename": filename,
+                    "audio_bitrate": audio_bitrate, "copy_to_output": copy_to_output,
+                    "output_subfolder": output_subfolder, "blend_schedule": blend_schedule,
+                    "boundary_tone_match": boundary_tone_match,
+                    "color_stabilization": color_stabilization},
+                "video": _video_output_item(final_path),
+                "video_sha256": _file_sha256(final_path), "frames": total_output_frames,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            })
         _publish_final_review_preview(manifest, published_video, status)
         return {
             "ui": {
@@ -28745,7 +28786,7 @@ def _checkpoint_output_compatibility(value: dict[str, Any]) -> dict[str, Any]:
         "generation_fingerprint", "generation_fingerprint_lineage")}
 
 
-def _checkpoint_selection_manifest(value: Any) -> dict[str, Any] | None:
+def _checkpoint_selection_manifest(value: Any, *, freeze_editorial=False) -> dict[str, Any] | None:
     """Build one immutable generated lineage directly from manager selection."""
     if value is None or (isinstance(value, str) and not value.strip()):
         return None
@@ -29008,11 +29049,11 @@ def _checkpoint_selection_manifest(value: Any) -> dict[str, Any] | None:
     elif isinstance(archived_plan.get("source_timeline"), dict):
         manifest["source_timeline"] = _json_document(
             archived_plan["source_timeline"])
-    if final_cut_branch != current_branch(run_name):
+    if freeze_editorial or final_cut_branch != current_branch(run_name):
         # Freeze the selected path's cut, not the unrelated assignment view's
         # cut. Keep output folders and generation lineage exactly as selected.
         manifest["editorial"] = _json_document(editorial)
-        manifest["final_cut_source"] = {"branch_id": final_cut_branch}
+        manifest["final_cut_source"] = {"branch_id": final_cut_branch, **({"editorial_revision": editorial["revision"]} if freeze_editorial else {})}
     if chapter_output:
         # Picture-only alternates cannot change duration. Earlier chapters'
         # base timing metadata suffices; do not require their alternate media.
@@ -29021,8 +29062,8 @@ def _checkpoint_selection_manifest(value: Any) -> dict[str, Any] | None:
             if int(item.get("scene", 0)) >= scope_start_scene]}
         manifest, _path = _chapter_manifest_from_manifest(
             manifest, int(selected_chapter["number"]), persist=False)
-        if final_cut_branch != current_branch(run_name):
-            manifest["final_cut_source"] = {"branch_id": final_cut_branch}
+        if freeze_editorial or final_cut_branch != current_branch(run_name):
+            manifest["final_cut_source"] = {"branch_id": final_cut_branch, **({"editorial_revision": editorial["revision"]} if freeze_editorial else {})}
     else:
         _validate_manifest(manifest)
     if selection.get("processing_source") is not None:
@@ -29984,6 +30025,18 @@ async def _list_saved_checkpoints(request):
             "H3 checkpoint listing took %.2fs for run %s (%s)",
             elapsed, run_name, "full graph" if include_graph else "active only")
     return web.json_response(payload)
+
+
+async def _prepare_saved_delivery(request):
+    from .delivery_snapshot import prepare, DeliveryConflict
+    try:
+        body = await request.json()
+        payload = await asyncio.to_thread(prepare, sys.modules[__name__], body)
+        return web.json_response(payload, headers={"Cache-Control": "no-store"})
+    except DeliveryConflict as exc:
+        return web.json_response({"error": str(exc)}, status=409)
+    except (OSError, TypeError, ValueError) as exc:
+        return web.json_response({"error": str(exc)}, status=400)
 
 
 async def _inspect_project_storage(request):
@@ -31802,6 +31855,8 @@ _submit_candidate_batch_command = scoped_review(_submit_candidate_batch_command,
 
 if (PromptServer is not None and web is not None and
         getattr(PromptServer, "instance", None) is not None):
+    PromptServer.instance.routes.post(
+        "/minimax_h3_context_loop/delivery/prepare")(_prepare_saved_delivery)
     PromptServer.instance.routes.get(
         "/minimax_h3_context_loop/working-branches")(_working_branch_command)
     PromptServer.instance.routes.post(
@@ -31953,6 +32008,7 @@ CHAIN_NODE_CLASS_MAPPINGS = {
     "MiniMaxH3ProjectAssetManager": MiniMaxH3ProjectAssetManager,
     "MiniMaxH3ChainRunManager": MiniMaxH3ChainRunManager,
     "MiniMaxH3ChainCheckpointManager": MiniMaxH3ChainCheckpointManager,
+    "MiniMaxH3ChainDeliverySource": MiniMaxH3ChainDeliverySource,
     "MiniMaxH3ChainFirstSceneImage": MiniMaxH3ChainFirstSceneImage,
     "MiniMaxH3ChainFrameIndexSwitch": MiniMaxH3ChainFrameIndexSwitch,
     "MiniMaxH3ReferenceVideoPrepare": MiniMaxH3ReferenceVideoPrepare,
@@ -32007,6 +32063,7 @@ CHAIN_NODE_CLASS_MAPPINGS = {
 scope_nodes(CHAIN_NODE_CLASS_MAPPINGS)
 
 CHAIN_NODE_DISPLAY_NAME_MAPPINGS = {
+    "MiniMaxH3ChainDeliverySource": "MiniMax H3 Saved Delivery Source",
     "MiniMaxH3LipSyncOptions": "MiniMax H3 Lip-Sync Options",
     "MiniMaxH3GenerationProfile": "MiniMax H3 Generation Profile",
     "MiniMaxH3ChainPolicy": "MiniMax H3 Manual Chain Policy (Legacy)",

--- a/delivery_snapshot.py
+++ b/delivery_snapshot.py
@@ -1,0 +1,159 @@
+"""Read-only, exact saved-source snapshots for native H3 delivery.
+
+Snapshots are portable descriptions, not authorization tokens. Execution still
+verifies the immutable artifacts and uses H3's normal assembly implementation.
+"""
+import copy
+import hashlib
+import json
+import math
+
+from .branch_scope import branch_id, branch_scope
+
+FORMAT = "h3_delivery_snapshot_v1"
+MAX_BYTES = 16 * 1024 * 1024
+
+
+class DeliveryConflict(ValueError):
+    pass
+
+
+def _json(value):
+    return json.dumps(value, ensure_ascii=False, sort_keys=True,
+                      separators=(",", ":"), allow_nan=False)
+
+
+def _digest(value):
+    return hashlib.sha256(_json(value).encode("utf-8")).hexdigest()
+
+
+def _timing(chain, manifest):
+    editorial = chain._manifest_editorial(manifest)
+    _editorial, _records, frames = chain._editorial_timeline_records(
+        manifest["run_name"], manifest["segments"], editorial)
+    origin = int((manifest.get("chapter") or {}).get("editorial_origin_frame", 0))
+    return editorial, frames, origin
+
+
+def presentation_segments(chain, manifest):
+    """Use the captured picture descriptors, never reread a mutable ALT sidecar."""
+    pictures = manifest.get("delivery_pictures")
+    if pictures is None:
+        return None
+    bases = manifest.get("segments", [])
+    if not isinstance(pictures, list) or len(pictures) != len(bases):
+        raise ValueError("Frozen delivery has an invalid picture selection.")
+    for base, picture in zip(bases, pictures):
+        if not isinstance(picture, dict) or any(picture.get(key) != base.get(key)
+                for key in ("index", "id", "raw_frames", "delivered_frames")):
+            raise ValueError("Frozen delivery pictures change scene identity or timing.")
+        if picture.get("revision") != base.get("revision") and (
+                picture.get("presentation_base_revision") != base.get("revision")
+                or picture.get("presentation_alternate_revision") != picture.get("revision")
+                or picture.get("presentation_media_mode") != "picture_only"):
+            raise ValueError("Frozen delivery contains an unrelated picture alternate.")
+        chain._verify_segment_artifacts(picture, int(base["index"]))
+    return copy.deepcopy(pictures)
+
+
+def subtitle_cues(manifest, frames, origin):
+    """Return frozen pre-prelude cues, or None for ordinary live editorial."""
+    record = manifest.get("delivery_subtitles")
+    if record is None:
+        return None
+    if (not isinstance(record, dict) or record.get("version") != 1
+            or record.get("frame_count") != frames
+            or record.get("timeline_origin_frame") != origin
+            or not isinstance(record.get("cues"), list)):
+        raise ValueError("Frozen delivery subtitle timing no longer matches the manifest.")
+    for cue in record["cues"]:
+        if not isinstance(cue, dict) or not isinstance(cue.get("text"), str):
+            raise ValueError("Frozen delivery contains invalid subtitle text.")
+        start, end = cue.get("start"), cue.get("end")
+        if (isinstance(start, bool) or isinstance(end, bool)
+                or not isinstance(start, (int, float))
+                or not isinstance(end, (int, float))
+                or not math.isfinite(start) or not math.isfinite(end)
+                or start < 0 or end <= start or end > frames / 24.0 + 1e-9):
+            raise ValueError("Frozen delivery contains invalid subtitle timing.")
+    return copy.deepcopy(record["cues"])
+
+
+def prepare(chain, body):
+    if not isinstance(body, dict) or not isinstance(body.get("selection"), dict):
+        raise ValueError("Delivery preparation requires a saved checkpoint selection.")
+    selection = copy.deepcopy(body["selection"])
+    run = chain._strict_run_name(selection.get("run_name"))
+    selected = branch_id(selection.get("_branch_id", "main"))
+    if selection.get("output_mode") != "workflow_local":
+        raise ValueError("Delivery preparation requires an explicit workflow-local checkpoint pin.")
+    if selection.get("processing_source") is not None:
+        raise ValueError("Processed sources need their own immutable delivery snapshot adapter.")
+    cut = selection.get("final_cut_branch_id")
+    if not isinstance(cut, str) or cut == "auto":
+        raise ValueError("Choose an explicit final-cut branch for delivery.")
+    branch_id(cut)
+    revision = body.get("editorial_revision")
+    if not isinstance(revision, str) or not revision:
+        raise ValueError("Refresh the final cut before preparing a delivery snapshot.")
+    with branch_scope(run, selected):
+        manifest = chain._checkpoint_selection_manifest(selection, freeze_editorial=True)
+        source = manifest.get("final_cut_source") or {}
+        if source.get("branch_id") != cut or source.get("editorial_revision") != revision:
+            raise DeliveryConflict("The final cut changed. Refresh it and review delivery again.")
+        editorial, frames, origin = _timing(chain, manifest)
+        # Validate chosen alternate media during preparation as well as execution.
+        pictures = chain._editorial_presentation_segments(run, manifest["segments"], editorial)
+        manifest["delivery_pictures"] = copy.deepcopy(pictures)
+        cues = chain._editorial_subtitle_cues(run, editorial, frames,
+                                            timeline_origin_frames=origin)
+        manifest["delivery_subtitles"] = {"version": 1, "frame_count": frames,
+                                          "timeline_origin_frame": origin, "cues": cues}
+        prelude = chain._validate_prelude(manifest)
+    value = {"format": FORMAT, "version": 1, "run_name": run,
+             "branch_id": selected, "selection": selection, "manifest": manifest}
+    value["id"] = _digest(value)
+    serialized = _json(value)
+    if len(serialized.encode("utf-8")) > MAX_BYTES:
+        raise ValueError("This delivery snapshot exceeds the supported size.")
+    return {"version": 1, "snapshot_id": value["id"], "snapshot_json": serialized,
+            "summary": {"run_name": run, "branch_id": selected,
+                        "final_cut_branch_id": cut, "editorial_revision": revision,
+                        "scene_start": manifest["segments"][0]["index"],
+                        "scene_end": manifest["segments"][-1]["index"],
+                        "frames": frames + (int(prelude["frame_count"]) if prelude else 0),
+                        "fps": chain.FPS, "subtitle_count": len(cues),
+                        "pictures": [{"scene": item["index"],
+                                      "revision": str(item.get("revision") or ""),
+                                      "scene_id": str(item.get("id") or "")}
+                                     for item in pictures]}}
+
+
+def load(chain, serialized):
+    if not isinstance(serialized, str) or len(serialized.encode("utf-8")) > MAX_BYTES:
+        raise ValueError("Invalid delivery snapshot size or type.")
+    value = json.loads(serialized)
+    if not isinstance(value, dict) or value.get("format") != FORMAT or value.get("version") != 1:
+        raise ValueError("Unsupported delivery snapshot. Prepare it again in SceneWeaver.")
+    saved_id = value.pop("id", None)
+    if not isinstance(saved_id, str) or saved_id != _digest(value):
+        raise ValueError("The delivery snapshot was changed or damaged. Prepare it again.")
+    run = chain._strict_run_name(value.get("run_name"))
+    selected = branch_id(value.get("branch_id"))
+    manifest = value.get("manifest")
+    if (not isinstance(manifest, dict) or manifest.get("run_name") != run
+            or manifest.get("_branch_id", "main") != selected
+            or "editorial" not in manifest or "delivery_subtitles" not in manifest
+            or "delivery_pictures" not in manifest):
+        raise ValueError("The delivery snapshot has inconsistent source identity.")
+    with branch_scope(run, selected):
+        # Verify that the destination branch still exists; never fall back to Original.
+        chain.WorkingBranches(chain._output_root(), run)._load_record(selected)
+        segments = chain._validate_manifest(manifest)
+        editorial, frames, origin = _timing(chain, manifest)
+        presentation_segments(chain, manifest)
+        chain._validate_prelude(manifest)
+        subtitle_cues(manifest, frames, origin)
+    manifest["delivery_snapshot_id"] = saved_id
+    manifest["_delivery_snapshot_json"] = serialized
+    return manifest

--- a/delivery_snapshot.py
+++ b/delivery_snapshot.py
@@ -105,8 +105,11 @@ def prepare(chain, body):
         # Validate chosen alternate media during preparation as well as execution.
         pictures = chain._editorial_presentation_segments(run, manifest["segments"], editorial)
         manifest["delivery_pictures"] = copy.deepcopy(pictures)
+        catalog = (chain.ProjectAssetStore(chain._input_root(), chain._output_root())
+                   .load(run, repair=False)
+                   if editorial.get("subtitles", {}).get("mode") == "preview_srt" else {})
         cues = chain._editorial_subtitle_cues(run, editorial, frames,
-                                            timeline_origin_frames=origin)
+                                            timeline_origin_frames=origin, catalog=catalog)
         manifest["delivery_subtitles"] = {"version": 1, "frame_count": frames,
                                           "timeline_origin_frame": origin, "cues": cues}
         prelude = chain._validate_prelude(manifest)

--- a/docs/NODE_REFERENCE.md
+++ b/docs/NODE_REFERENCE.md
@@ -6,6 +6,11 @@ remain documented by the node tooltips and the linked specialist guides.
 
 ## Read a node at a glance
 
+**MiniMax H3 Saved Delivery Source** accepts an API-prepared `snapshot_json` and
+outputs a verified saved manifest for H3 Chain Assemble. See the
+[saved delivery guide](SAVED_DELIVERY.md) for preparation, source verification and
+recovery. It leaves the active checkpoint selection unchanged.
+
 The tables use this direction:
 
 ```text

--- a/docs/SAVED_DELIVERY.md
+++ b/docs/SAVED_DELIVERY.md
@@ -1,0 +1,90 @@
+# Saved delivery snapshots
+
+The delivery interface captures a saved checkpoint lineage, its selected final cut,
+picture alternates and subtitle cues for later assembly. A subsequent editorial
+edit or lyric catalog change does not change the prepared job. Preparation reads
+the project without activating checkpoints, restoring a Plan or claiming ownership.
+
+Connect **MiniMax H3 Saved Delivery Source** to the manifest input of **H3 Chain
+Assemble**. Paste the exact `snapshot_json` returned by the API into the source
+node. Assemble retains its existing audio, blend, color and output controls. This
+path reads saved media; it does not generate new scenes. Blending can still require
+the connected VAE. Ordinary Checkpoint Manager and Assemble behavior is unchanged
+when no delivery snapshot is present.
+
+## Prepare a source
+
+`POST /minimax_h3_context_loop/delivery/prepare`, JSON body:
+
+```json
+{
+  "selection": {
+    "run_name": "my_film",
+    "_branch_id": "main",
+    "output_mode": "workflow_local",
+    "final_cut_branch_id": "main",
+    "lineage": [{ "scene": 1, "revision": "0123456789abcdef0123456789abcdef" }]
+  },
+  "editorial_revision": "the revision from the reviewed checkpoint inventory"
+}
+```
+
+Use the existing native `checkpointLocalSelectionJson` helper to produce an exact
+saved lineage. A named destination branch and the final-cut source branch are
+separate identities; both must be explicit. `final_cut_branch_id: "auto"` and
+legacy/adopting checkpoint selections are rejected. Native chapter pins also
+accept `output_scope: "chapter"`, `scope_start_scene` and `scope_end_scene`.
+
+A successful response contains `version: 1`, a SHA-256 `snapshot_id`, the opaque
+`snapshot_json` string, and a `summary` with project/branch/cut identity, editorial
+revision, scene range, duration in frames, fps, cue count and picture revisions.
+The response is not cached. A changed editorial revision returns HTTP 409; invalid
+selections and unavailable media return HTTP 400. Media hashing can take time.
+
+Preserve `snapshot_json` as a string. Parsing and reserializing it in JavaScript can
+round native uint64 seeds and invalidate its digest. The source node verifies the
+digest, branch existence and captured media hashes again at execution. Missing or
+changed source bytes stop the job; it does not substitute today's active take.
+The snapshot is a source description, not an authorization token or a media bundle.
+
+## Native browser adapter
+
+`web/h3_delivery_core.mjs` exports `DELIVERY_VERSION = 1`,
+`prepareDelivery(api, selection, editorialRevision)` and
+`deliveryPrompt(serialized, target, snapshotJson, settings)`. The checkpoint entry
+module re-exports them for discovery. SceneWeaver discovers this interface from
+the installed H3 pack; merely updating the companion does not install it.
+
+Run native before-queue hooks and ComfyUI's `graphToPrompt` first. The recipe helper
+retains full workflow metadata, replaces only the chosen Assemble manifest input
+with a saved source, and keeps its serialized ancillary dependencies. Queue its
+returned target with native partial execution. It never changes the live graph.
+
+Supported ancillary producers are `VAELoader`, `LoadAudio`, `VHS_LoadAudioUpload`,
+`MiniMaxH3AudioTracks`, `MiniMaxH3SourceTimeline`, `MiniMaxH3ProjectAssetManager`,
+`LoadVideo`, `VHS_LoadVideo` and `VHS_LoadVideoFFmpeg`. Unknown dependencies are
+rejected rather than silently omitted. Connected scalar overrides and
+`overwrite_existing` are rejected. Processed/upscale sources need a separate
+adapter and are not supported by this snapshot version.
+
+## Output and recovery
+
+Normal native MP4, audio and subtitle outputs remain available. Frozen assembly
+also writes `<video-stem>.delivery.json` alongside the project video. It records
+the exact source snapshot, scalar assembly settings, video path, SHA-256 and frame
+count. Connected audio/VAE producers remain in the native queued workflow and
+history; the record alone is not a portable reconstruction of those dependencies.
+The record is not currently copied with `copy_to_output` or exposed as a grouped
+download by SceneWeaver. Preserve the referenced source media for reassembly.
+
+## Validation
+
+Run `python3 tests/_delivery_snapshot_unit_test.py` with Torch, safetensors and
+FFmpeg installed, and `node --test tests/_delivery_snapshot_js_test.mjs`. The Python
+case uses native H3 functions, temporary synthetic projects and real CPU FFmpeg
+assembly. It checks a 48-frame video with audio, frozen ALT pixels and SRT text,
+chapter subtitle offsets, separate branch identities, stale revision rejection,
+source corruption and preparation without project writes. Its async route check
+requires working local socket notifications. The JS cases validate dependency
+preservation and rejection of unsupported sources. These checks do not establish
+GPU generation or production workflow parity.

--- a/docs/SAVED_DELIVERY.md
+++ b/docs/SAVED_DELIVERY.md
@@ -4,6 +4,8 @@ The delivery interface captures a saved checkpoint lineage, its selected final c
 picture alternates and subtitle cues for later assembly. A subsequent editorial
 edit or lyric catalog change does not change the prepared job. Preparation reads
 the project without activating checkpoints, restoring a Plan or claiming ownership.
+Subtitle catalogs are read without filesystem recovery: a missing or corrupt primary
+can use its valid backup without restoring files during preparation.
 
 Connect **MiniMax H3 Saved Delivery Source** to the manifest input of **H3 Chain
 Assemble**. Paste the exact `snapshot_json` returned by the API into the source
@@ -84,7 +86,9 @@ FFmpeg installed, and `node --test tests/_delivery_snapshot_js_test.mjs`. The Py
 case uses native H3 functions, temporary synthetic projects and real CPU FFmpeg
 assembly. It checks a 48-frame video with audio, frozen ALT pixels and SRT text,
 chapter subtitle offsets, separate branch identities, stale revision rejection,
-source corruption and preparation without project writes. Its async route check
+source corruption and preparation without project writes, including a real
+mirror-only subtitle catalog. `python3 tests/_catalog_readonly_unit_test.py` also
+checks corrupt primary catalogs and unchanged ordinary recovery. Its async route check
 requires working local socket notifications. The JS cases validate dependency
 preservation and rejection of unsupported sources. These checks do not establish
 GPU generation or production workflow parity.

--- a/project_assets.py
+++ b/project_assets.py
@@ -511,7 +511,9 @@ class ProjectAssetStore:
         }
 
     @_project_mutation
-    def load(self, project: Any, *, create: bool = False) -> dict[str, Any]:
+    def load(self, project: Any, *, create: bool = False, repair: bool = True) -> dict[str, Any]:
+        if create and not repair:
+            raise ValueError("A read-only catalog load cannot create a project.")
         directory, name = self._project_dir(project)
         path = os.path.join(directory, "catalog.json")
         backup_path = os.path.join(self._backup_dir(name)[0], "catalog.json")
@@ -523,7 +525,12 @@ class ProjectAssetStore:
                     catalog = json.load(handle)
             except (OSError, json.JSONDecodeError) as exc:
                 primary_error = exc
-        if catalog is None and os.path.isfile(backup_path):
+        if catalog is None and not repair and os.path.isfile(backup_path):
+            # Preview callers may use the recovery mirror without restoring
+            # the primary catalog or creating a filesystem lock.
+            with open(backup_path, "r", encoding="utf-8") as handle:
+                catalog = json.load(handle)
+        if catalog is None and repair and os.path.isfile(backup_path):
             # A writer may repair or replace the primary between our first
             # read and recovery. Re-check it while holding the same process
             # and filesystem locks used by catalog commits so an older mirror

--- a/tests/_catalog_readonly_unit_test.py
+++ b/tests/_catalog_readonly_unit_test.py
@@ -1,0 +1,47 @@
+"""Preview reads may use catalog mirrors without repairing project files."""
+import json
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from project_assets import ProjectAssetStore, PROJECT_ASSET_FORMAT
+
+
+def tree(root):
+    return {str(p.relative_to(root)): p.read_bytes() if p.is_file() else None
+            for p in root.rglob('*')}
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    store = ProjectAssetStore(str(root / 'input'), str(root / 'output'))
+    primary = root / 'input/h3_projects/film/catalog.json'
+    backup = root / 'output/h3_chains/film/project_assets/catalog.json'
+    backup.parent.mkdir(parents=True)
+    catalog = {'format': PROJECT_ASSET_FORMAT, 'version': 1, 'project': 'film',
+               'revision': 'saved', 'assets': [{'id': 'lyrics', 'kind': 'audio', 'lyrics': 'saved'}]}
+    backup.write_text(json.dumps(catalog))
+    for damaged_primary in (False, True):
+        if damaged_primary:
+            primary.parent.mkdir(parents=True)
+            primary.write_text('broken catalog')
+        before = tree(root)
+        with patch('project_assets._atomic_json', side_effect=AssertionError('preview wrote catalog')):
+            assert store.load('film', repair=False)['assets'] == catalog['assets']
+        assert tree(root) == before
+    # Ordinary reads retain existing recovery behavior.
+    assert store.load('film')['revision'] == 'saved'
+    assert json.loads(primary.read_text())['revision'] == 'saved'
+    primary.write_text(json.dumps({**catalog, 'revision': 'newer'}))
+    assert store.load('film', repair=False)['revision'] == 'newer'
+    before = tree(root)
+    try:
+        store.load('empty', create=True, repair=False)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('Read-only load allowed project creation')
+    assert tree(root) == before
+print('Read-only catalog: missing/corrupt primary, backup isolation, newer primary and ordinary recovery pass')

--- a/tests/_delivery_snapshot_js_test.mjs
+++ b/tests/_delivery_snapshot_js_test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { deliveryPrompt, prepareDelivery } from '../web/h3_delivery_core.mjs';
+
+function fixture() {
+    return {workflow: {id: 'original', extra: {native: true}}, output: {
+        assemble: {class_type: 'MiniMaxH3ChainAssemble', inputs: {
+            manifest: ['loop', 0], blend_video_vae: ['vae', 0], filename: 'native', audio_bitrate: 192}},
+        vae: {class_type: 'VAELoader', inputs: {vae_name: 'native.safetensors'}},
+        loop: {class_type: 'MiniMaxH3ChainLoopEnd', inputs: {}},
+        other: {class_type: 'SaveImage', inputs: {images: ['sampler', 0]}},
+    }};
+}
+
+test('delivery substitutes only the saved source and retains serialized ancillary inputs and metadata', () => {
+    const graph = fixture(), before = JSON.stringify(graph);
+    const result = deliveryPrompt(graph, 'assemble', 'exact JSON with 18446744073709551615', {filename: 'saved'});
+    assert.equal(result.prompt.workflow, graph.workflow);
+    assert.equal(result.prompt.output.vae, graph.output.vae);
+    assert.deepEqual(Object.keys(result.prompt.output).sort(), ['assemble', 'h3_saved_delivery', 'vae']);
+    assert.equal(result.prompt.output.h3_saved_delivery.inputs.snapshot_json, 'exact JSON with 18446744073709551615');
+    assert.equal(result.prompt.output.assemble.inputs.audio_bitrate, 192);
+    assert.equal(JSON.stringify(graph), before);
+});
+
+test('generating ancillary branches, connected overrides and overwrite are rejected', () => {
+    const graph = fixture();
+    graph.output.vae.class_type = 'UnknownSampler';
+    assert.throws(() => deliveryPrompt(graph, 'assemble', 'saved'), /source adapter/);
+    graph.output.vae.class_type = 'VAELoader';
+    graph.output.assemble.inputs.audio_bitrate = ['vae', 0];
+    assert.throws(() => deliveryPrompt(graph, 'assemble', 'saved', {audio_bitrate: 256}), /connected/);
+    graph.output.assemble.inputs.overwrite_existing = true;
+    assert.throws(() => deliveryPrompt(graph, 'assemble', 'saved'), /overwrite/);
+});
+
+test('preparation requires the exact requested branch and editorial revision', async () => {
+    const selection = {run_name: 'film', _branch_id: 'a'.repeat(32), final_cut_branch_id: 'main'};
+    const summary = {run_name: 'film', branch_id: selection._branch_id, final_cut_branch_id: 'main', editorial_revision: 'cut'};
+    const api = {async fetchApi(path, options) {
+        assert.equal(path, '/minimax_h3_context_loop/delivery/prepare');
+        assert.deepEqual(JSON.parse(options.body), {selection, editorial_revision: 'cut'});
+        return Response.json({version: 1, snapshot_json: 'exact native text', snapshot_id: 'd'.repeat(64), summary});
+    }};
+    assert.equal((await prepareDelivery(api, selection, 'cut')).snapshot_json, 'exact native text');
+    summary.branch_id = 'main';
+    await assert.rejects(prepareDelivery(api, selection, 'cut'), /different delivery source/);
+});

--- a/tests/_delivery_snapshot_unit_test.py
+++ b/tests/_delivery_snapshot_unit_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Native saved-cut snapshot, immutable audio/captions and real FFmpeg delivery."""
+import asyncio
+import copy
+import importlib
+import importlib.util
+import json
+import pathlib
+import subprocess
+import tempfile
+from unittest.mock import patch
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("delivery_helpers", ROOT / "tests/_checkpoint_revision_unit_test.py")
+h = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(h)
+chain = h.chain
+delivery = importlib.import_module(chain.__package__ + ".delivery_snapshot")
+import torch
+from safetensors.torch import save_file
+
+
+def files(root):
+    return {str(p.relative_to(root)): p.read_bytes() for p in root.rglob('*') if p.is_file()}
+
+
+def reject(call, text):
+    try:
+        call()
+    except (ValueError, OSError) as exc:
+        assert text in str(exc), str(exc)
+    else:
+        raise AssertionError("Expected rejection: " + text)
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        h.folder_paths.output_directory = tmp
+        run = root / 'h3_chains' / 'delivery_test'
+        compat = {'width': 64, 'height': 48, 'fps': 24, 'audio_mode': 'generated_audio',
+                  'context_length': 0, 'audio_context_length': 0, 'video_blend_frames': 0}
+        def save(scene, token, color, parent=None, alternate=False):
+            record, _ = h.write_revision(run, scene, token, 18446744073709551615,
+                active=not alternate, predecessor=parent, run_name=run.name, compatibility=compat,
+                context_length=0, audio_context_length=0)
+            segment = record['segment']
+            segment.update(raw_frames=24, delivered_frames=24, sample_rate=8000)
+            subprocess.run(['ffmpeg', '-v', 'error', '-y', '-f', 'lavfi', '-i',
+                f'color=c={color}:s=64x48:r=24:d=1', '-an', '-c:v', 'libx264',
+                '-pix_fmt', 'yuv420p', str(root / segment['segment'])], check=True)
+            wave = torch.sin(torch.arange(8000) * (2 * torch.pi * 220 / 8000)).reshape(1, 1, -1).repeat(1, 2, 1) * .1
+            save_file({'delivered_audio': wave}, str(root / segment['checkpoint']))
+            segment['segment_sha256'] = h.digest(root / segment['segment'])
+            segment['checkpoint_sha256'] = h.digest(root / segment['checkpoint'])
+            if alternate:
+                segment.update(take_kind='editorial_alternate', alternate_of_revision='1' * 32)
+            (root / segment['revision_metadata']).write_text(json.dumps(record))
+            if not alternate:
+                (root / segment['metadata']).write_text(json.dumps(record))
+            return record
+        first = save(1, '1' * 32, 'blue')
+        second = save(2, '2' * 32, 'green', first)
+        alt = save(1, 'a' * 32, 'red', alternate=True)
+        (run / 'plan.json').write_text(json.dumps({'run_name': run.name, 'shots': [{'id': 'scene_1'}, {'id': 'scene_2'}]}))
+        editorial_path = run / 'editorial.json'
+        editorial_path.write_text(json.dumps({'revision': 'e' * 32,
+            'scene_order': [{'scene': 1, 'scene_id': 'scene_1'}, {'scene': 2, 'scene_id': 'scene_2'}],
+            'chapters': [{'id': 'first', 'start_scene_id': 'scene_1'},
+                         {'id': 'second', 'start_scene_id': 'scene_2'}],
+            'subtitles': {'mode': 'preview_srt', 'asset_id': 'lyrics', 'offset_seconds': 0},
+            'replacements': [{'scene': 1, 'scene_id': 'scene_1', 'base_revision': '1' * 32,
+                              'alternate_revision': 'a' * 32, 'media_mode': 'picture_only'}]}))
+        selection = {'run_name': run.name, '_branch_id': 'main', 'output_mode': 'workflow_local',
+                     'final_cut_branch_id': 'main', 'lineage': [{'scene': 1, 'revision': '1' * 32},
+                                                             {'scene': 2, 'revision': '2' * 32}]}
+        revision = chain._load_run_editorial(run.name)['revision']
+        body = {'selection': selection, 'editorial_revision': revision}
+        catalog = {'assets': [{'id': 'lyrics', 'kind': 'audio', 'tag': 'lyrics',
+                               'lyrics': '1\n00:00:00,000 --> 00:00:01,500\nFrozen caption'}]}
+        # Branch destination and final-cut source are separate identities.
+        branch = chain.WorkingBranches(tmp, run.name).create('main', 'Second cut',
+            {'plan_json': json.dumps({'shots': [{'id': 'scene_1'}, {'id': 'scene_2'}]})})
+        named = {**body, 'selection': {**selection, '_branch_id': branch['id']}}
+        with patch.object(chain.ProjectAssetStore, 'load', return_value=catalog):
+            named_snapshot = delivery.prepare(chain, named)
+            response = asyncio.run(chain._prepare_saved_delivery(h.JsonRequest(body)))
+        assert response.status == 200 and json.loads(response.text)['snapshot_id']
+        named_manifest = delivery.load(chain, named_snapshot['snapshot_json'])
+        assert named_manifest['_branch_id'] == branch['id']
+        assert named_manifest['final_cut_source']['branch_id'] == 'main'
+        assert chain.current_branch(run.name) == 'main'
+        conflict = asyncio.run(chain._prepare_saved_delivery(h.JsonRequest({**body, 'editorial_revision': 'stale'})))
+        assert conflict.status == 409
+        before = files(root)
+        with patch.object(chain.ProjectAssetStore, 'load', return_value=catalog):
+            prepared = delivery.prepare(chain, body)
+            chapter = delivery.prepare(chain, {**body, 'selection': {**selection,
+                'output_scope': 'chapter', 'scope_start_scene': 2, 'scope_end_scene': 2}})
+        assert files(root) == before, 'preparing a delivery changed project files'
+        assert chapter['summary']['scene_start'] == 2 and chapter['summary']['frames'] == 24
+        assert prepared['summary']['pictures'][0]['revision'] == 'a' * 32
+        assert prepared['summary']['frames'] == 48 and prepared['summary']['subtitle_count'] == 1
+        assert '18446744073709551615' in prepared['snapshot_json']
+        reject(lambda: delivery.prepare(chain, {**body, 'editorial_revision': 'wrong'}), 'final cut changed')
+        reject(lambda: delivery.prepare(chain, {**body, 'selection': {**selection, 'output_mode': None}}), 'workflow-local')
+        reject(lambda: delivery.load(chain, prepared['snapshot_json'].replace('Frozen caption', 'Changed caption')), 'changed or damaged')
+        # Later branch edits do not change queued picture or subtitles.
+        editorial_path.write_text(json.dumps({'revision': 'f' * 32, 'replacements': [], 'subtitles': {'mode': 'off'}}))
+        altered = copy.deepcopy(alt)
+        altered['segment']['segment'] = first['segment']['segment']
+        altered['segment']['segment_sha256'] = first['segment']['segment_sha256']
+        (root / alt['segment']['revision_metadata']).write_text(json.dumps(altered))
+        with patch.object(chain.ProjectAssetStore, 'load', side_effect=AssertionError('delivery read live captions')):
+            chapter_manifest = delivery.load(chain, chapter['snapshot_json'])
+            assert chapter_manifest['chapter']['editorial_origin_frame'] == 24
+            chapter_cues = delivery.subtitle_cues(chapter_manifest, 24, 24)
+            assert chapter_cues[0]['start'] == 0 and chapter_cues[0]['end'] == .5
+            manifest = chain.MiniMaxH3ChainDeliverySource().load(prepared['snapshot_json'])[0]
+            assert manifest['editorial']['replacements'][0]['alternate_revision'] == 'a' * 32
+            assert delivery.subtitle_cues(manifest, 48, 0)[0]['text'] == 'Frozen caption'
+            result = chain.MiniMaxH3ChainAssemble().assemble(manifest, 'generated', 'frozen_cut', 128, blend_schedule='0')
+        path = pathlib.Path(result['result'][0] if isinstance(result, dict) else result[0])
+        assert path.is_file(), result
+        record = json.loads(path.with_suffix('.delivery.json').read_text())
+        assert record['snapshot_json'] == prepared['snapshot_json']
+        assert record['video_sha256'] == h.digest(path)
+        assert record['settings']['audio_source'] == 'generated'
+        streams = json.loads(subprocess.check_output(['ffprobe', '-v', 'error', '-show_streams', '-of', 'json', str(path)]))['streams']
+        assert {s['codec_type'] for s in streams} >= {'audio', 'video'}
+        assert int(next(s for s in streams if s['codec_type'] == 'video')['nb_frames']) == 48
+        assert 'Frozen caption' in path.with_suffix('.srt').read_text()
+        # Check that the accepted ALT supplies red pixels, not the now-active blue original.
+        pixel = subprocess.check_output(['ffmpeg', '-v', 'error', '-i', str(path), '-frames:v', '1', '-vf', 'scale=1:1', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-'])
+        assert pixel[0] > pixel[2] + 100, tuple(pixel)
+        (run / 'branches' / branch['id'] / 'branch.json').unlink()
+        reject(lambda: delivery.load(chain, named_snapshot['snapshot_json']), 'branch')
+        # An unavailable immutable source must fail rather than fall back to today's cut.
+        (root / alt['segment']['segment']).write_bytes(b'damaged')
+        reject(lambda: delivery.load(chain, prepared['snapshot_json']), 'SHA-256')
+        print('Frozen delivery: read-only preparation, exact lineage/ALT, caption isolation, uint64 text, corruption rejection and real 48-frame MP4 with audio pass')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/_delivery_snapshot_unit_test.py
+++ b/tests/_delivery_snapshot_unit_test.py
@@ -102,6 +102,17 @@ def main():
         assert prepared['summary']['pictures'][0]['revision'] == 'a' * 32
         assert prepared['summary']['frames'] == 48 and prepared['summary']['subtitle_count'] == 1
         assert '18446744073709551615' in prepared['snapshot_json']
+        # Real mirror-only catalog: preparation must not repair the missing primary.
+        asset_module = importlib.import_module(chain.__package__ + '.project_assets')
+        backup = run / 'project_assets/catalog.json'
+        backup.parent.mkdir(parents=True)
+        backup.write_text(json.dumps({**catalog, 'format': asset_module.PROJECT_ASSET_FORMAT,
+                                      'version': 1, 'project': run.name, 'revision': 'saved'}))
+        before_recovery = files(root)
+        recovered = delivery.prepare(chain, body)
+        assert files(root) == before_recovery
+        assert not (root / 'h3_projects' / run.name).exists()
+        assert recovered['summary']['subtitle_count'] == 1
         reject(lambda: delivery.prepare(chain, {**body, 'editorial_revision': 'wrong'}), 'final cut changed')
         reject(lambda: delivery.prepare(chain, {**body, 'selection': {**selection, 'output_mode': None}}), 'workflow-local')
         reject(lambda: delivery.load(chain, prepared['snapshot_json'].replace('Frozen caption', 'Changed caption')), 'changed or damaged')

--- a/web/h3_chain_checkpoint_manager.js
+++ b/web/h3_chain_checkpoint_manager.js
@@ -1,3 +1,4 @@
+export { DELIVERY_VERSION, prepareDelivery, deliveryPrompt } from './h3_delivery_core.mjs';
 import {app} from "/scripts/app.js";
 import {api} from "/scripts/api.js";
 import {mountStorageInspector} from "./h3_storage_inspector.mjs?v=0.1.0";

--- a/web/h3_delivery_core.mjs
+++ b/web/h3_delivery_core.mjs
@@ -1,0 +1,44 @@
+// Native saved-delivery protocol. Serialize with ComfyUI first; retain exact
+// native node payloads and full workflow metadata, and substitute only the
+// selected assembly's source with its prepared immutable manifest loader.
+export const DELIVERY_VERSION = 1;
+const sourceClass = 'MiniMaxH3ChainDeliverySource';
+const link = value => Array.isArray(value) && value.length === 2 && typeof value[0] === 'string' && Number.isInteger(value[1]);
+// Additional native input producers need a contract before isolated delivery
+// can promise to avoid generation. Unknown graph branches are never discarded.
+const ancillaryClasses = new Set(['VAELoader', 'LoadAudio', 'VHS_LoadAudioUpload', 'MiniMaxH3AudioTracks', 'MiniMaxH3SourceTimeline', 'MiniMaxH3ProjectAssetManager', 'LoadVideo', 'VHS_LoadVideo', 'VHS_LoadVideoFFmpeg']);
+export async function prepareDelivery(api, selection, editorialRevision) {
+    const response = await api.fetchApi('/minimax_h3_context_loop/delivery/prepare', {
+        method: 'POST', headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({selection, editorial_revision:editorialRevision}),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || 'Cannot prepare this saved delivery.');
+    if (result.version !== 1 || typeof result.snapshot_json !== 'string' || !/^[0-9a-f]{64}$/.test(result.snapshot_id)
+            || result.summary?.run_name !== selection.run_name || result.summary.branch_id !== (selection._branch_id || 'main')
+            || result.summary.final_cut_branch_id !== selection.final_cut_branch_id
+            || result.summary.editorial_revision !== editorialRevision) throw new Error('H3 returned a different delivery source. Refresh and prepare again.');
+    return result;
+}
+export function deliveryPrompt(serialized, target, snapshotJson, settings = {}) {
+    const nodes = serialized?.output, assembly = nodes?.[target];
+    if (assembly?.class_type !== 'MiniMaxH3ChainAssemble') throw new Error('The selected native assembly output is unavailable.');
+    if (typeof snapshotJson !== 'string' || !snapshotJson) throw new Error('Prepare a saved delivery source first.');
+    const allowedSettings = new Set(['audio_source','filename','audio_bitrate','copy_to_output','output_subfolder','blend_schedule','boundary_tone_match','color_stabilization']);
+    for (const key of Object.keys(settings)) if (!allowedSettings.has(key) || link(assembly.inputs[key])) throw new Error(`Delivery setting ${key} is unknown or connected. Edit its native source before preparing delivery.`);
+    const inputs = {...assembly.inputs, ...settings};
+    if (inputs.overwrite_existing) throw new Error('Turn off overwrite_existing before isolated delivery; completed outputs must be preserved.');
+    let sourceId = 'h3_saved_delivery'; while (nodes[sourceId]) sourceId += '_';
+    inputs.manifest = [sourceId, 0];
+    const output = {[target]: {...assembly, inputs}, [sourceId]: {class_type:sourceClass, inputs:{snapshot_json:snapshotJson}}};
+    const seen = new Set([target, sourceId]);
+    const visit = id => {
+        if (seen.has(id)) return; seen.add(id);
+        const node = nodes[id];
+        if (!node || !ancillaryClasses.has(node.class_type)) throw new Error(`Delivery input #${id} (${node?.class_type || 'missing'}) needs an isolated source adapter. Use a dedicated saved-delivery workflow for this source.`);
+        output[id] = node;
+        for (const value of Object.values(node.inputs || {})) if (link(value)) visit(value[0]);
+    };
+    for (const value of Object.values(inputs)) if (link(value)) visit(value[0]);
+    return {prompt:{...serialized, output}, target};
+}


### PR DESCRIPTION
A prepared saved cut currently follows mutable editorial, alternate metadata and lyric catalog state at assembly time. Add a read-only preparation API and Saved Delivery Source node that capture exact checkpoint lineage, picture artifact descriptors and caption cues; native Assemble verifies and uses that captured source after later edits.

The native browser helper preserves ComfyUI serialization and workflow metadata, replaces the selected assembly manifest input, and retains supported ancillary readers/VAE inputs. Unknown dependencies, connected scalar overrides and overwriting are rejected. Existing checkpoint/assembly behavior is unchanged without a snapshot. Each frozen assembly writes a source/settings record beside its video.

Validation: six native Python regression scripts passed, including real CPU FFmpeg assembly of a 48-frame synthetic video with audio, frozen ALT pixels, SRT captions and an exact source record. The new test also covers chapter offsets, branch identity, stale cuts, damaged media and preparation without project writes. Three native JS tests passed. SceneWeaver adapter/browser coverage is tracked in its repository.

This is a draft integration interface. Production GPU execution has not been tested. Processed sources, additional ancillary nodes and full portable dependency recovery remain separate work. The complete API, limitations and reproduction commands are in docs/SAVED_DELIVERY.md.
