### PR TITLE
Preview and save native sequence timing and caption edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ scene can be reviewed, retried, checkpointed, resumed, and assembled later.
   DeRoPE/upscale checkpoints and recoverable VIDEO PNG publication.
 - Provides scene review, alternate takes, branch management, final assembly,
   masked editing, and deferred upscaling.
+- Exposes [saved-sequence edit previews](docs/SAVED_SEQUENCE_COMMANDS.md) for
+  companion tools, including native trim boundaries and continuation impact.
 - Captures a frame from a saved Review Gate preview into the Project Asset
   Carousel as a new tagged picture, without replacing the original take.
 

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -9606,7 +9606,7 @@ def _parse_timed_lyrics(value: Any) -> list[dict[str, Any]]:
 
 def _editorial_subtitle_cues(
         run_name: str, editorial: dict[str, Any], total_frames: int,
-        timeline_origin_frames: int = 0
+        timeline_origin_frames: int = 0, *, catalog: dict[str, Any] | None = None
         ) -> list[dict[str, Any]]:
     settings = editorial.get("subtitles") or {}
     if settings.get("mode") != "preview_srt":
@@ -9615,7 +9615,8 @@ def _editorial_subtitle_cues(
     if not asset_id:
         raise ValueError(
             "Editorial subtitles are enabled but no lyrics asset is selected.")
-    catalog = ProjectAssetStore(_input_root(), _output_root()).load(run_name)
+    if catalog is None:
+        catalog = ProjectAssetStore(_input_root(), _output_root()).load(run_name)
     asset = next((item for item in catalog.get("assets", [])
                   if str(item.get("id") or "") == asset_id), None)
     if asset is None or asset.get("kind") != "audio":

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -9464,7 +9464,7 @@ def _editorial_context_tail(
 def _editorial_timeline_records(
         run_name: Any, segments: list[dict[str, Any]],
         editorial: dict[str, Any] | None = None,
-        natural_start_frame: int = 0) -> tuple[
+        natural_start_frame: int = 0, *, validate_dependencies: bool = True) -> tuple[
             dict[str, Any], list[dict[str, Any]], int]:
     """Resolve editorial clip positions without changing the chain manifest."""
     editorial = editorial or _load_run_editorial(run_name)
@@ -9480,8 +9480,9 @@ def _editorial_timeline_records(
             _editorial_trimmed_segment(segment, editorial)
         for offset, segment in enumerate(segments, start=1)
     }
-    _require_current_editorial_dependencies(
-        base_editorial_segments, "H3 editorial assembly")
+    if validate_dependencies:
+        _require_current_editorial_dependencies(
+            base_editorial_segments, "H3 editorial assembly")
     presentation_segments = _editorial_presentation_segments(
         run_name, segments, editorial)
     editorial_segments = {
@@ -30003,12 +30004,13 @@ async def _inspect_project_storage(request):
     return web.json_response(payload, headers={"Cache-Control": "no-store"})
 
 
-def _save_run_editorial_document_unlocked(body: Any) -> dict[str, Any]:
+def _save_run_editorial_document_unlocked(body: Any, *, persist: bool = True) -> dict[str, Any]:
     if not isinstance(body, dict):
         raise ValueError("H3 run editorial data must be a JSON object.")
     document = dict(body)
-    document["updated_at"] = datetime.now(timezone.utc).isoformat(
-        timespec="seconds").replace("+00:00", "Z")
+    if persist:
+        document["updated_at"] = datetime.now(timezone.utc).isoformat(
+            timespec="seconds").replace("+00:00", "Z")
     normalized = _normalize_run_editorial(document, body.get("run_name"))
     checkpoint_dir = os.path.join(_run_dir({"run_name": normalized["run_name"]}), "checkpoints")
     draft = normalized.get("alternate_draft")
@@ -30085,8 +30087,9 @@ def _save_run_editorial_document_unlocked(body: Any) -> dict[str, Any]:
                 (scene, str(segment.get("id") or ""),
                  str(trim["scene_id"])))
         _editorial_trimmed_segment(segment, normalized)
-    normalized["revision"] = uuid.uuid4().hex
-    _atomic_json(_run_editorial_path(normalized["run_name"]), normalized)
+    if persist:
+        normalized["revision"] = uuid.uuid4().hex
+        _atomic_json(_run_editorial_path(normalized["run_name"]), normalized)
     return normalized
 
 
@@ -30116,6 +30119,27 @@ def _save_run_editorial_document(
                     "Refresh Plan Studio before editing again; the newer "
                     "editorial data was not overwritten.")
         return _save_run_editorial_document_unlocked(body)
+
+
+async def _editorial_command(request):
+    from .editorial_commands import command
+    try:
+        body = await request.json()
+        proof = None
+        if isinstance(body, dict) and body.get("action") == "apply":
+            run_name = _strict_run_name(body.get("run_name"))
+            rejection = _project_write_rejection(request, run_name, "update the saved sequence")
+            if rejection is not None:
+                return rejection
+            proof = _request_project_ownership(request)
+        result = await asyncio.to_thread(command, sys.modules[__name__], body, proof)
+        return web.json_response(result, headers={"Cache-Control": "no-store"})
+    except ProjectOwnershipError as exc:
+        return web.json_response({"error": str(exc)}, status=423)
+    except EditorialConflictError as exc:
+        return web.json_response({"error": str(exc)}, status=409)
+    except (OSError, TypeError, ValueError, KeyError) as exc:
+        return web.json_response({"error": str(exc)}, status=400)
 
 
 async def _update_run_editorial(request):
@@ -31803,6 +31827,8 @@ _submit_candidate_batch_command = scoped_review(_submit_candidate_batch_command,
 
 if (PromptServer is not None and web is not None and
         getattr(PromptServer, "instance", None) is not None):
+    PromptServer.instance.routes.post(
+        "/minimax_h3_context_loop/editorial/command")(_editorial_command)
     PromptServer.instance.routes.get(
         "/minimax_h3_context_loop/working-branches")(_working_branch_command)
     PromptServer.instance.routes.post(

--- a/docs/SAVED_SEQUENCE_COMMANDS.md
+++ b/docs/SAVED_SEQUENCE_COMMANDS.md
@@ -1,0 +1,85 @@
+# Saved sequence editing interface
+
+Companions can inspect, preview and save H3 editorial trims, placements, timing
+locks and subtitle settings through `POST /minimax_h3_context_loop/editorial/command`.
+The native browser module `h3_editorial_commands.mjs` exports
+`EDITORIAL_COMMAND_VERSION = 1` and `editorialCommand(api, body, options)`; Plan
+Studio re-exports it for discovery. Existing Studio saves remain compatible.
+
+All bodies identify `run_name` and `branch_id` (`main` for Original). The response
+echoes both identities and `version: 1`. This interface edits saved editorial
+state. It does not change the authored Plan, active checkpoint pointers, immutable
+take files or generation order, and it does not queue rendering.
+
+## Inspect, preview, apply
+
+1. Send `{"action":"inspect","run_name":"film","branch_id":"main"}`.
+   The response supplies a source `stamp`, saved scenes with exact revision IDs,
+   native `safe_out_frames`, current trim/placement/lock values, subtitle settings,
+   timed audio-asset choices and resolved sequence timing. Existing invalid
+   timeline/caption settings are reported in `timeline.error` so they can be fixed.
+2. Send `action: "preview"` with that `stamp` and one `patch`. For example:
+
+   ```json
+   {
+     "scene": {
+       "scene": 1,
+       "scene_id": "arrival",
+       "revision": "0123456789abcdef0123456789abcdef",
+       "out_frame": 48,
+       "start_frame": 120
+     }
+   }
+   ```
+
+   The response contains a `preview_token`, the patch, and a native timeline:
+   resolved scene/gap records, frame count, caption cues and direct/transitive
+   continuation mismatches. Review this response before writing.
+3. Send `action: "apply"` with the same identities, `stamp`, exact `patch` and
+   `preview_token`, using the normal native project ownership headers. Apply
+   rechecks source state under the checkpoint lock before the conditional native
+   editorial save. Its response contains the saved editorial revision and timing.
+
+Inspection and preview do not claim ownership, create checkpoint locks or repair
+catalogs. A missing/corrupt primary catalog can be read from its valid backup
+without restoring files. Apply uses native project ownership; a preview token is
+not authorization. A changed cut, checkpoint metadata, asset catalog or patch
+requires another review (HTTP 409). Ownership failures return 423; invalid input
+returns 400. Responses are not cached. A failed/lost response after a write must
+be reconciled by inspecting current state, not automatically resubmitted.
+
+## Supported changes
+
+| Patch | Meaning |
+| --- | --- |
+| `scene.out_frame` | Retained delivered prefix, using a native valid video/audio cut point; `null` or full delivered length removes the trim. No in-trim is introduced. |
+| `scene.start_frame` | Explicit requested frame, 0–864000; `null` restores natural placement. H3 resolves ordering and pushes overlaps forward, retaining gaps. |
+| `scene.locked` | Boolean timing lock. A locked scene must be unlocked in a separate saved edit before changing its trim or placement. |
+| `subtitles` | One settings patch containing `mode` (`off` / `preview_srt`), `asset_id` and/or `offset_seconds` (-3600 to 3600). Uses the native timed-lyrics parser. |
+
+Each request edits either one exact saved scene or subtitle settings. Other
+editorial fields, including chapters, final-cut replacements and ALT drafts, pass
+through native validation unchanged. Audio waveform monitoring, soundtrack/Plan
+routing, incoming blend settings and chapter authoring use their existing separate
+interfaces; they are not added to this command.
+
+A shortened endpoint can invalidate saved continuations downstream. Preview
+reports these scenes using H3's native dependency analysis; the user may save the
+edit and regenerate from the first affected scene. Native assembly continues to
+reject stale continuations. The diagnostic timeline alone is not evidence that
+the saved sequence is currently assemblable. No checkpoint is deleted or restored
+by accepting an edit.
+
+## Validation
+
+`python3 tests/_editorial_commands_unit_test.py` exercises real native validation,
+ownership, named-branch isolation, read-only catalog recovery, locks, captions,
+checkpoint/catalog conflicts and direct/transitive continuation impact using
+temporary synthetic project metadata. Its async route checks need working local
+socket notifications.
+
+`python3 tests/_editorial_commands_ffmpeg_test.py` additionally uses Torch,
+safetensors and CPU FFmpeg to assemble real synthetic media. It compares native
+preview records with a 168-frame output containing a trimmed ALT picture, a black
+gap, the base take's generated audio, silence during the gap, and shifted SRT cues.
+It does not execute GPU generation or validate a production workflow.

--- a/editorial_commands.py
+++ b/editorial_commands.py
@@ -1,0 +1,176 @@
+"""Inspect, review and conditionally save native saved-sequence edits."""
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+from .branch_scope import branch_id, branch_scope
+
+VERSION = 1
+
+
+def digest(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(',', ':'),
+                                    ensure_ascii=False, allow_nan=False).encode()).hexdigest()
+
+
+def integer(value, minimum, maximum, label):
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError(f'{label} must be an integer between {minimum} and {maximum}.')
+    return value
+
+
+def state(chain, run, selected):
+    store = chain.WorkingBranches(chain._output_root(), run)
+    if not store.root.is_dir():
+        raise ValueError('The saved project is unavailable.')
+    store._load_record(selected)
+    pointers = store._pointers(selected)
+    segments = []
+    for index, metadata in sorted(pointers.items()):
+        segment = metadata.get('segment')
+        if not isinstance(segment, dict) or segment.get('index') != index or not segment.get('id'):
+            raise ValueError(f'Scene {index} has invalid saved checkpoint identity.')
+        segments.append(segment)
+    path = Path(chain._run_editorial_path(run))
+    editorial = (chain._normalize_run_editorial(chain._read_json(str(path)), run)
+                 if path.exists() else chain._load_run_editorial(run))
+    catalog = chain.ProjectAssetStore(chain._input_root(), chain._output_root()).load(run, repair=False)
+    stamp = digest([run, selected, path.exists(), editorial, pointers,
+                    catalog.get('revision', ''), catalog.get('assets', [])])
+    return {'editorial': editorial, 'segments': segments, 'catalog': catalog, 'stamp': stamp}
+
+
+def safe_outs(chain, segment):
+    raw, delivered = int(segment.get('raw_frames', 0)), int(segment.get('delivered_frames', 0))
+    if not 1 <= delivered <= raw <= chain.MAX_H3_FRAMES:
+        raise ValueError('The saved checkpoint has invalid raw/delivered duration.')
+    return [out for out in range(1, delivered + 1)
+            if out == delivered or (out * int(chain.AUDIO_HZ) % chain.FPS == 0
+                and chain._h3_prefix_frame_boundary_step(raw - delivered + out) is not None)]
+
+
+def describe(chain, run, source, document):
+    segments = source['segments']
+    adjusted = {int(s['index']): chain._editorial_trimmed_segment(s, document) for s in segments}
+    stale = chain._editorial_stale_dependencies(adjusted)
+    # A diagnostic can show the proposed layout and affected continuations.
+    # Actual native assembly retains its default dependency enforcement.
+    _, records, frames = chain._editorial_timeline_records(
+        run, segments, document, validate_dependencies=False)
+    cues = chain._editorial_subtitle_cues(run, document, frames, catalog=source['catalog'])
+    return {'frames': frames, 'fps': chain.FPS, 'subtitle_count': len(cues),
+            'cues': cues, 'stale_scenes': [{'scene': scene, 'reasons': reasons} for scene, reasons in stale.items()],
+            'records': [{k: v for k, v in record.items() if k != 'segment'} for record in records]}
+
+
+def inspect(chain, run, selected, source):
+    document = source['editorial']
+    scenes = []
+    for segment in source['segments']:
+        index, identity = int(segment['index']), segment['id']
+        trim = next((v for v in document.get('trims', []) if v['scene_id'] == identity), None)
+        placement = next((v for v in document.get('placements', []) if v['scene_id'] == identity), None)
+        scenes.append({'scene': index, 'scene_id': identity,
+                       'revision': chain.checkpoint_revision_token(index, segment),
+                       'raw_frames': segment['raw_frames'], 'delivered_frames': segment['delivered_frames'],
+                       'out_frame': trim['out_frame'] if trim else segment['delivered_frames'],
+                       'start_frame': placement['start_frame'] if placement else None,
+                       'locked': identity in document.get('locked_scene_ids', []),
+                       'safe_out_frames': safe_outs(chain, segment)})
+    try:
+        timeline = describe(chain, run, source, document)
+    except ValueError as exc:
+        timeline = {'error': str(exc)}
+    return {'version': VERSION, 'run_name': run, 'branch_id': selected, 'stamp': source['stamp'],
+            'editorial_revision': document.get('revision', ''), 'scenes': scenes, 'timeline': timeline,
+            'subtitles': copy.deepcopy(document.get('subtitles', {})),
+            'subtitle_assets': [{'id': a['id'], 'tag': a.get('tag', a['id']),
+                                 'timed': bool(chain._parse_timed_lyrics(a.get('lyrics', '')))}
+                                for a in source['catalog'].get('assets', []) if a.get('kind') == 'audio']}
+
+
+def proposal(chain, run, source, patch):
+    if not isinstance(patch, dict) or len(patch) != 1 or next(iter(patch)) not in ('scene', 'subtitles'):
+        raise ValueError('Choose one scene edit or subtitle settings edit.')
+    document = copy.deepcopy(source['editorial'])
+    edit = patch.get('scene')
+    if edit is not None:
+        allowed = {'scene', 'scene_id', 'revision', 'out_frame', 'start_frame', 'locked'}
+        if not isinstance(edit, dict) or set(edit) - allowed or not set(edit) & {'out_frame', 'start_frame', 'locked'}:
+            raise ValueError('Unsupported saved scene edit.')
+        scene = integer(edit.get('scene'), 1, chain.MAX_SHOTS, 'Scene')
+        segment = next((s for s in source['segments'] if s['index'] == scene), None)
+        if (segment is None or segment['id'] != edit.get('scene_id')
+                or chain.checkpoint_revision_token(scene, segment) != edit.get('revision')):
+            raise chain.EditorialConflictError('The saved scene changed. Inspect this branch again.')
+        identity = segment['id']
+        if identity in document.get('locked_scene_ids', []) and set(edit) & {'out_frame', 'start_frame'}:
+            raise ValueError('Unlock this saved scene before changing its trim or placement.')
+        order = document.setdefault('scene_order', [])
+        if not any(row['scene'] == scene and row['scene_id'] == identity for row in order):
+            if any(row['scene'] == scene or row['scene_id'] == identity for row in order):
+                raise ValueError('The saved editorial scene order differs from the checkpoint. Refresh Plan Studio.')
+            order.append({'scene': scene, 'scene_id': identity})
+        if 'out_frame' in edit:
+            out = edit['out_frame']
+            if out is not None:
+                integer(out, 1, int(segment['delivered_frames']), 'Trim end')
+                if out not in safe_outs(chain, segment):
+                    raise ValueError('Trim end must use a native video/audio boundary.')
+            document['trims'] = [v for v in document.get('trims', []) if v['scene_id'] != identity]
+            if out is not None and out < int(segment['delivered_frames']):
+                document['trims'].append({'scene': scene, 'scene_id': identity, 'out_frame': out})
+        if 'start_frame' in edit:
+            start = edit['start_frame']
+            if start is not None:
+                integer(start, 0, 864000, 'Placement')
+            document['placements'] = [v for v in document.get('placements', []) if v['scene_id'] != identity]
+            if start is not None:
+                document['placements'].append({'scene': scene, 'scene_id': identity, 'start_frame': start})
+        if 'locked' in edit:
+            if type(edit['locked']) is not bool:
+                raise ValueError('Scene lock must be true or false.')
+            document['locked_scene_ids'] = [v for v in document.get('locked_scene_ids', []) if v != identity]
+            if edit['locked']:
+                document['locked_scene_ids'].append(identity)
+    else:
+        subtitles = patch['subtitles']
+        if not isinstance(subtitles, dict) or not subtitles or set(subtitles) - {'mode', 'asset_id', 'offset_seconds'}:
+            raise ValueError('Unsupported subtitle settings.')
+        document['subtitles'] = {**document.get('subtitles', {}), **subtitles}
+    normalized = chain._save_run_editorial_document_unlocked(document, persist=False)
+    return normalized, describe(chain, run, source, normalized)
+
+
+def command(chain, body, ownership=None):
+    if not isinstance(body, dict):
+        raise ValueError('Saved sequence commands require a JSON object.')
+    run = chain._strict_run_name(body.get('run_name'))
+    selected = branch_id(body.get('branch_id', 'main'))
+    action = body.get('action')
+    if action not in ('inspect', 'preview', 'apply'):
+        raise ValueError('Unknown saved sequence command.')
+    with branch_scope(run, selected):
+        if action == 'apply':
+            with chain.checkpoint_run_lock(chain._output_root(), run):
+                source = state(chain, run, selected)
+                if body.get('stamp') != source['stamp']:
+                    raise chain.EditorialConflictError('The saved cut, checkpoints or assets changed. Review the edit again.')
+                document, timeline = proposal(chain, run, source, body.get('patch'))
+                token = digest([source['stamp'], document])
+                if body.get('preview_token') != token:
+                    raise chain.EditorialConflictError('The reviewed edit changed. Preview it again.')
+                document['base_revision'] = source['editorial'].get('revision', '')
+                saved = chain._save_run_editorial_document(document, ownership)
+                return {'version': VERSION, 'run_name': run, 'branch_id': selected,
+                        'editorial': saved, 'timeline': timeline}
+        source = state(chain, run, selected)
+        if action == 'inspect':
+            return inspect(chain, run, selected, source)
+        if body.get('stamp') != source['stamp']:
+            raise chain.EditorialConflictError('The saved cut, checkpoints or assets changed. Inspect this branch again.')
+        document, timeline = proposal(chain, run, source, body.get('patch'))
+        return {'version': VERSION, 'run_name': run, 'branch_id': selected, 'stamp': source['stamp'],
+                'preview_token': digest([source['stamp'], document]), 'timeline': timeline,
+                'patch': copy.deepcopy(body['patch'])}

--- a/project_assets.py
+++ b/project_assets.py
@@ -511,7 +511,9 @@ class ProjectAssetStore:
         }
 
     @_project_mutation
-    def load(self, project: Any, *, create: bool = False) -> dict[str, Any]:
+    def load(self, project: Any, *, create: bool = False, repair: bool = True) -> dict[str, Any]:
+        if create and not repair:
+            raise ValueError("A read-only catalog load cannot create a project.")
         directory, name = self._project_dir(project)
         path = os.path.join(directory, "catalog.json")
         backup_path = os.path.join(self._backup_dir(name)[0], "catalog.json")
@@ -523,7 +525,12 @@ class ProjectAssetStore:
                     catalog = json.load(handle)
             except (OSError, json.JSONDecodeError) as exc:
                 primary_error = exc
-        if catalog is None and os.path.isfile(backup_path):
+        if catalog is None and not repair and os.path.isfile(backup_path):
+            # Preview callers may use the recovery mirror without restoring
+            # the primary catalog or creating a filesystem lock.
+            with open(backup_path, "r", encoding="utf-8") as handle:
+                catalog = json.load(handle)
+        if catalog is None and repair and os.path.isfile(backup_path):
             # A writer may repair or replace the primary between our first
             # read and recovery. Re-check it while holding the same process
             # and filesystem locks used by catalog commits so an older mirror

--- a/tests/_catalog_readonly_unit_test.py
+++ b/tests/_catalog_readonly_unit_test.py
@@ -1,0 +1,47 @@
+"""Preview reads may use catalog mirrors without repairing project files."""
+import json
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from project_assets import ProjectAssetStore, PROJECT_ASSET_FORMAT
+
+
+def tree(root):
+    return {str(p.relative_to(root)): p.read_bytes() if p.is_file() else None
+            for p in root.rglob('*')}
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    store = ProjectAssetStore(str(root / 'input'), str(root / 'output'))
+    primary = root / 'input/h3_projects/film/catalog.json'
+    backup = root / 'output/h3_chains/film/project_assets/catalog.json'
+    backup.parent.mkdir(parents=True)
+    catalog = {'format': PROJECT_ASSET_FORMAT, 'version': 1, 'project': 'film',
+               'revision': 'saved', 'assets': [{'id': 'lyrics', 'kind': 'audio', 'lyrics': 'saved'}]}
+    backup.write_text(json.dumps(catalog))
+    for damaged_primary in (False, True):
+        if damaged_primary:
+            primary.parent.mkdir(parents=True)
+            primary.write_text('broken catalog')
+        before = tree(root)
+        with patch('project_assets._atomic_json', side_effect=AssertionError('preview wrote catalog')):
+            assert store.load('film', repair=False)['assets'] == catalog['assets']
+        assert tree(root) == before
+    # Ordinary reads retain existing recovery behavior.
+    assert store.load('film')['revision'] == 'saved'
+    assert json.loads(primary.read_text())['revision'] == 'saved'
+    primary.write_text(json.dumps({**catalog, 'revision': 'newer'}))
+    assert store.load('film', repair=False)['revision'] == 'newer'
+    before = tree(root)
+    try:
+        store.load('empty', create=True, repair=False)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('Read-only load allowed project creation')
+    assert tree(root) == before
+print('Read-only catalog: missing/corrupt primary, backup isolation, newer primary and ordinary recovery pass')

--- a/tests/_editorial_commands_ffmpeg_test.py
+++ b/tests/_editorial_commands_ffmpeg_test.py
@@ -1,0 +1,89 @@
+"""Saved-cut review and real native assembly agree on frames, ALT, gap and SRT."""
+import importlib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('editorial_media_helpers', ROOT / 'tests/_checkpoint_revision_unit_test.py')
+h = importlib.util.module_from_spec(spec); spec.loader.exec_module(h)
+chain = h.chain
+commands = importlib.import_module(chain.__package__ + '.editorial_commands')
+import torch
+from safetensors.torch import save_file
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp); h.folder_paths.output_directory = tmp
+    run = root / 'h3_chains/cut_media'
+    compatibility = {'width': 64, 'height': 48, 'fps': 24, 'audio_mode': 'generated_audio',
+                     'context_length': 0, 'audio_context_length': 0, 'video_blend_frames': 0}
+    def media(scene, revision, color, parent=None, alternate=False):
+        record, _ = h.write_revision(run, scene, revision, 18446744073709551615, active=not alternate,
+            predecessor=parent, run_name=run.name, compatibility=compatibility,
+            context_length=0, audio_context_length=0)
+        segment = record['segment']; segment.update(raw_frames=124, delivered_frames=108, sample_rate=8000)
+        subprocess.run(['ffmpeg', '-v', 'error', '-y', '-f', 'lavfi', '-i',
+            f'color=c={color}:s=64x48:r=24:d=4.5', '-an', '-c:v', 'libx264', '-pix_fmt', 'yuv420p',
+            str(root / segment['segment'])], check=True)
+        frequency = 660 if alternate else scene * 220
+        wave = torch.sin(torch.arange(36000) * (2 * torch.pi * frequency / 8000)).reshape(1, 1, -1).repeat(1, 2, 1) * .1
+        save_file({'delivered_audio': wave}, str(root / segment['checkpoint']))
+        segment['segment_sha256'] = h.digest(root / segment['segment'])
+        segment['checkpoint_sha256'] = h.digest(root / segment['checkpoint'])
+        if alternate:
+            segment.update(take_kind='editorial_alternate', alternate_of_revision='1' * 32)
+        (root / segment['revision_metadata']).write_text(json.dumps(record))
+        if not alternate: (root / segment['metadata']).write_text(json.dumps(record))
+        return record
+    first = media(1, '1' * 32, 'blue')
+    media(2, '2' * 32, 'green', first)
+    media(1, 'a' * 32, 'red', alternate=True)
+    (run / 'plan.json').write_text(json.dumps({'run_name': run.name, 'shots': [{'id': 'scene_1'}, {'id': 'scene_2'}]}))
+    (run / 'editorial.json').write_text(json.dumps({'revision': 'e' * 32,
+        'scene_order': [{'scene': 1, 'scene_id': 'scene_1'}, {'scene': 2, 'scene_id': 'scene_2'}],
+        'chapters': [{'id': 'one', 'start_scene_id': 'scene_1'}, {'id': 'two', 'start_scene_id': 'scene_2'}],
+        'replacements': [{'scene': 1, 'scene_id': 'scene_1', 'base_revision': '1' * 32,
+                          'alternate_revision': 'a' * 32, 'media_mode': 'picture_only'}],
+        'subtitles': {'mode': 'preview_srt', 'asset_id': 'lyrics', 'offset_seconds': .5}}))
+    catalog = root / 'h3_projects' / run.name / 'catalog.json'; catalog.parent.mkdir(parents=True)
+    catalog.write_text(json.dumps({'format': 'h3_project_assets_v1', 'version': 1, 'project': run.name,
+        'assets': [{'id': 'lyrics', 'kind': 'audio', 'tag': 'lyrics',
+                    'lyrics': '1\n00:00:01,000 --> 00:00:03,000\nAligned words'}]}))
+    owner = chain.claim_project_ownership(tmp, run.name, 'media-test-owner')
+    proof = {'owner_id': 'media-test-owner', 'epoch': owner['epoch']}
+    base = {'run_name': run.name, 'branch_id': 'main'}
+    def edit(patch):
+        view = commands.command(chain, {**base, 'action': 'inspect'})
+        request = {**base, 'stamp': view['stamp'], 'patch': {'scene': patch}}
+        preview = commands.command(chain, {**request, 'action': 'preview'})
+        return commands.command(chain, {**request, 'action': 'apply', 'preview_token': preview['preview_token']}, proof)
+    edit({'scene': 1, 'scene_id': 'scene_1', 'revision': '1' * 32, 'out_frame': 48})
+    final = edit({'scene': 2, 'scene_id': 'scene_2', 'revision': '2' * 32, 'start_frame': 60})
+    assert not final['timeline']['stale_scenes']
+    assert [(r['kind'], r['start_frame'], r['frame_count']) for r in final['timeline']['records']] == [('scene', 0, 48), ('gap', 48, 12), ('scene', 60, 108)]
+    assert final['timeline']['frames'] == 168
+    manifest = chain._checkpoint_selection_manifest({'run_name': run.name, 'output_mode': 'workflow_local',
+        'final_cut_branch_id': 'main', 'lineage': [{'scene': 1, 'revision': '1' * 32}, {'scene': 2, 'revision': '2' * 32}]})
+    result = chain.MiniMaxH3ChainAssemble().assemble(manifest, 'generated', 'edited_cut', 128, blend_schedule='0')
+    video = Path(result['result'][0] if isinstance(result, dict) else result[0])
+    streams = json.loads(subprocess.check_output(['ffprobe', '-v', 'error', '-show_streams', '-of', 'json', str(video)]))['streams']
+    assert {s['codec_type'] for s in streams} >= {'video', 'audio'}
+    assert int(next(s for s in streams if s['codec_type'] == 'video')['nb_frames']) == 168
+    pixel = subprocess.check_output(['ffmpeg', '-v', 'error', '-i', str(video), '-frames:v', '1', '-vf', 'scale=1:1', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-'])
+    assert pixel[0] > pixel[2] + 100, tuple(pixel)
+    gap = subprocess.check_output(['ffmpeg', '-v', 'error', '-ss', '2.1', '-i', str(video), '-frames:v', '1', '-vf', 'scale=1:1', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-'])
+    assert max(gap) < 8, tuple(gap)
+    def samples(start, duration):
+        raw = subprocess.check_output(['ffmpeg', '-v', 'error', '-ss', str(start), '-i', str(video),
+            '-t', str(duration), '-vn', '-ac', '1', '-ar', '8000', '-f', 'f32le', '-'])
+        return torch.frombuffer(bytearray(raw), dtype=torch.float32)
+    for start, expected in ((.2, 220), (2.7, 440)):
+        wave = samples(start, 1)
+        peak = int(torch.fft.rfft(wave).abs().argmax()) * 8000 / len(wave)
+        assert abs(peak - expected) < 4, (start, peak)
+    assert float(samples(2.05, .3).square().mean().sqrt()) < .005
+    assert '00:00:01,500 --> 00:00:03,500' in video.with_suffix('.srt').read_text()
+    assert 'Aligned words' in video.with_suffix('.srt').read_text()
+print('Native editorial media: review and 168-frame FFmpeg assembly agree on trimmed ALT, black gap, generated audio and shifted SRT')

--- a/tests/_editorial_commands_unit_test.py
+++ b/tests/_editorial_commands_unit_test.py
@@ -1,0 +1,137 @@
+"""Native saved-cut previews, exact continuation impact and conditional writes."""
+import asyncio
+import importlib
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('editorial_test_helpers', ROOT / 'tests/_checkpoint_revision_unit_test.py')
+h = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(h)
+chain = h.chain
+commands = importlib.import_module(chain.__package__ + '.editorial_commands')
+
+
+def tree(root):
+    return {str(p.relative_to(root)): p.read_bytes() if p.is_file() else None for p in root.rglob('*')}
+
+
+def reject(call, phrase):
+    try:
+        call()
+    except (ValueError, OSError) as exc:
+        assert phrase in str(exc), str(exc)
+    else:
+        raise AssertionError('Expected rejection: ' + phrase)
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    h.folder_paths.output_directory = tmp
+    run = root / 'h3_chains/cut_test'
+    previous, pointer_bytes = None, {}
+    for index in range(1, 4):
+        record, _ = h.write_revision(run, index, str(index) * 32, 18446744073709551615,
+                                     active=True, predecessor=previous, run_name=run.name)
+        record['segment'].update(raw_frames=124, delivered_frames=108,
+            resolved_context_length=39 if index > 1 else 0, resolved_audio_context_length=0,
+            generated_continuity='off', predecessor_editorial_out_frames=108)
+        for key in ('metadata', 'revision_metadata'):
+            path = root / record['segment'][key]
+            path.write_text(json.dumps(record))
+            pointer_bytes[str(path)] = path.read_bytes()
+        previous = record
+    path = run / 'editorial.json'
+    original = {'run_name': run.name, 'revision': 'e' * 32,
+        'scene_order': [{'scene': n, 'scene_id': f'scene_{n}'} for n in range(1, 4)],
+        'chapters': [{'id': 'opening', 'title': 'Opening', 'start_scene_id': 'scene_1', 'text': 'Keep notes'}],
+        'subtitles': {'mode': 'preview_srt', 'asset_id': 'lyrics', 'offset_seconds': 0}}
+    path.write_text(json.dumps(original))
+    backup = run / 'project_assets/catalog.json'
+    backup.parent.mkdir()
+    catalog = {'format': 'h3_project_assets_v1', 'version': 1, 'project': run.name, 'revision': 'catalog-1',
+        'assets': [{'id': 'lyrics', 'tag': 'song', 'kind': 'audio',
+                    'lyrics': '1\n00:00:01,000 --> 00:00:02,000\nSaved words'}]}
+    backup.write_text(json.dumps(catalog))
+    owner = 'editorial-test-workflow'
+    ownership = chain.claim_project_ownership(tmp, run.name, owner)
+    proof = {'owner_id': owner, 'epoch': ownership['epoch']}
+    base = {'run_name': run.name, 'branch_id': 'main'}
+    before = tree(root)
+    inspected = commands.command(chain, {**base, 'action': 'inspect'})
+    assert inspected['scenes'][0]['safe_out_frames'] and 48 in inspected['scenes'][0]['safe_out_frames']
+    assert 47 not in inspected['scenes'][0]['safe_out_frames']
+    patch = {'scene': {'scene': 1, 'scene_id': 'scene_1', 'revision': '1' * 32, 'out_frame': 48}}
+    request = {**base, 'stamp': inspected['stamp'], 'patch': patch}
+    preview = commands.command(chain, {**request, 'action': 'preview'})
+    assert tree(root) == before, 'inspection or preview changed project files'
+    assert preview['timeline']['frames'] == 264
+    assert [v['scene'] for v in preview['timeline']['stale_scenes']] == [2, 3]
+    assert 'depends on stale scene 2' in preview['timeline']['stale_scenes'][1]['reasons']
+    assert not (root / 'h3_projects').exists(), 'preview repaired the catalog'
+    invalid = {**patch['scene'], 'out_frame': 47}
+    reject(lambda: commands.command(chain, {**request, 'action': 'preview', 'patch': {'scene': invalid}}), 'native video/audio boundary')
+    apply = {**request, 'action': 'apply', 'preview_token': preview['preview_token']}
+    reject(lambda: commands.command(chain, apply), 'read-only')
+    saved = commands.command(chain, apply, proof)
+    assert saved['editorial']['trims'][0]['out_frame'] == 48
+    assert saved['editorial']['chapters'][0]['text'] == 'Keep notes'
+    assert all(Path(filename).read_bytes() == content for filename, content in pointer_bytes.items())
+    reject(lambda: commands.command(chain, apply, proof), 'changed')
+    segments = commands.state(chain, run.name, 'main')['segments']
+    reject(lambda: chain._editorial_timeline_records(run.name, segments, saved['editorial']), 'older editorial endpoint')
+
+    def edit(patch):
+        current = commands.command(chain, {**base, 'action': 'inspect'})
+        request = {**base, 'stamp': current['stamp'], 'patch': patch}
+        preview = commands.command(chain, {**request, 'action': 'preview'})
+        return commands.command(chain, {**request, 'action': 'apply', 'preview_token': preview['preview_token']}, proof)
+
+    # Reset duration, move the original first picture after the second, and lock it.
+    edit({'scene': {**patch['scene'], 'out_frame': None, 'start_frame': 400}})
+    locked = edit({'scene': {'scene': 1, 'scene_id': 'scene_1', 'revision': '1' * 32, 'locked': True}})
+    assert not locked['timeline']['stale_scenes']
+    assert [r['scene'] for r in locked['timeline']['records'] if r['kind'] == 'scene'] == [2, 3, 1]
+    current = commands.command(chain, {**base, 'action': 'inspect'})
+    reject(lambda: commands.command(chain, {**base, 'action': 'preview', 'stamp': current['stamp'], 'patch': patch}), 'Unlock')
+    captions = edit({'subtitles': {'offset_seconds': -0.5}})
+    assert captions['timeline']['cues'][0]['start'] == .5
+    assert captions['editorial']['locked_scene_ids'] == ['scene_1']
+    # Catalog changes invalidate a reviewed patch before it writes.
+    current = commands.command(chain, {**base, 'action': 'inspect'})
+    request = {**base, 'stamp': current['stamp'], 'patch': {'subtitles': {'mode': 'off'}}}
+    preview = commands.command(chain, {**request, 'action': 'preview'})
+    catalog['assets'][0]['lyrics'] = 'changed outside the companion'
+    backup.write_text(json.dumps(catalog))
+    reject(lambda: commands.command(chain, {**request, 'action': 'apply', 'preview_token': preview['preview_token']}, proof), 'assets changed')
+    catalog['assets'][0]['lyrics'] = '1\n00:00:01,000 --> 00:00:02,000\nSaved words'
+    backup.write_text(json.dumps(catalog))
+    current = commands.command(chain, {**base, 'action': 'inspect'})
+    request = {**base, 'stamp': current['stamp'], 'patch': {'subtitles': {'mode': 'off'}}}
+    preview = commands.command(chain, {**request, 'action': 'preview'})
+    pointer = run / 'checkpoints/clip_0003.json'
+    old_pointer = pointer.read_bytes()
+    metadata = json.loads(old_pointer); metadata['segment']['seed'] = 'another saved input'
+    pointer.write_text(json.dumps(metadata))
+    reject(lambda: commands.command(chain, {**request, 'action': 'apply', 'preview_token': preview['preview_token']}, proof), 'checkpoints or assets changed')
+    pointer.write_bytes(old_pointer)
+    # A named branch owns its editorial changes without touching Original.
+    authored = {'plan_json': json.dumps({'shots': [{'id': f'scene_{n}'} for n in range(1, 4)]})}
+    branch = chain.WorkingBranches(tmp, run.name).create('main', 'Separate cut', authored, 3)
+    named = {**base, 'branch_id': branch['id']}
+    original_bytes = path.read_bytes()
+    current = commands.command(chain, {**named, 'action': 'inspect'})
+    named_request = {**named, 'stamp': current['stamp'], 'patch': {'subtitles': {'mode': 'off'}}}
+    named_preview = commands.command(chain, {**named_request, 'action': 'preview'})
+    commands.command(chain, {**named_request, 'action': 'apply', 'preview_token': named_preview['preview_token']}, proof)
+    assert path.read_bytes() == original_bytes
+    assert json.loads((run / 'branches' / branch['id'] / 'editorial.json').read_text())['subtitles']['mode'] == 'off'
+    assert chain.current_branch(run.name) == 'main'
+    # Route serialization and its error statuses use real async worker dispatch.
+    response = asyncio.run(chain._editorial_command(h.JsonRequest({**base, 'action': 'inspect'})))
+    assert response.status == 200 and json.loads(response.text)['version'] == 1
+    response = asyncio.run(chain._editorial_command(h.JsonRequest({**request, 'stamp': 'stale', 'action': 'preview'})))
+    assert response.status == 409
+print('Saved editorial: read-only previews, native trim grid, transitive continuation impact, locks, captions, ownership and stale-source rejection pass')

--- a/web/h3_chain_plan_studio.js
+++ b/web/h3_chain_plan_studio.js
@@ -1,5 +1,6 @@
 import {app} from "/scripts/app.js";
 import {api} from "/scripts/api.js";
+export {EDITORIAL_COMMAND_VERSION, editorialCommand} from "./h3_editorial_commands.mjs";
 import {StudioBranches, BranchDrafts, branchOperationId, branchWidgetTransaction, branchRequestPath, workingBranchId} from "./h3_working_branches.mjs?v=0.7.19";
 import {branchPolicyNodes, captureBranchPolicyInputs, restoreBranchPolicyInputs} from "./h3_plan_restore_core.mjs?v=0.7.19";
 import {

--- a/web/h3_editorial_commands.mjs
+++ b/web/h3_editorial_commands.mjs
@@ -1,0 +1,12 @@
+export const EDITORIAL_COMMAND_VERSION = 1;
+export async function editorialCommand(api, body, options = {}) {
+    const response = await api.fetchApi('/minimax_h3_context_loop/editorial/command', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        ...options, body: JSON.stringify(body),
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || 'Cannot manage this saved sequence.');
+    if (result.version !== EDITORIAL_COMMAND_VERSION || result.run_name !== body.run_name
+            || result.branch_id !== (body.branch_id || 'main')) throw new Error('H3 returned another saved sequence. Refresh the project.');
+    return result;
+}


### PR DESCRIPTION
Companion editors need to show H3’s valid trim boundaries and the continuation effects of a saved-cut edit before writing. Add a versioned native inspect/preview/apply command for saved trims, placements, timing locks and subtitle settings. Preview reports resolved scene/gap timing, cues and direct/transitive stale continuations; apply verifies the reviewed cut, checkpoint metadata, catalog and patch under the checkpoint lock, then uses native ownership and editorial persistence.

The ordinary Studio save path and assembly dependency checks retain their defaults. Diagnostic timing can inspect stale continuations, while assembly still rejects them. Existing chapter metadata, picture replacements and ALT drafts remain in the native document. Catalog preview reads can use recovery mirrors without restoring project files; that small shared fix is also included in draft PR #58.

Validation: nine native Python regression scripts passed. Native media validation assembles a real 168-frame synthetic sequence with a trimmed ALT, black gap, original generated audio, silence in the gap and shifted SRT, matching the reviewed timing. Metadata tests cover ownership, named-branch isolation, invalid trim points, locks, stale checkpoints/catalogs, unchanged checkpoint files and read-only inspection. SceneWeaver separately passed its full browser and adapter suites. No production project or GPU generation was used.

This remains a draft integration interface. Chapter authoring, incoming blend/Plan policies, source soundtrack routing and durable companion draft/restart recovery are outside this command. See docs/SAVED_SEQUENCE_COMMANDS.md for the exact contract and test commands.
