### PR TITLE
Match browser duration rounding to the Python frame grid

### DIFF
--- a/docs/SCENE_TIMING_PARITY.md
+++ b/docs/SCENE_TIMING_PARITY.md
@@ -1,0 +1,24 @@
+# Browser duration rounding
+
+The Plan editor and Plan Studio round requested seconds up to the same 24 fps,
+`17k + 5` frame grid used by the Python compiler. JavaScript remainder preserves
+the sign of its left operand, so the browser must normalize a potentially
+negative remainder before adding its padding.
+
+| Requested duration | Required frames | Previous browser result | Compiler / corrected browser |
+|---|---:|---:|---:|
+| 1 second | 24 | 22 | 39 |
+| 6 seconds | 144 | 141 | 158 |
+| 12 seconds | 288 | 277 | 294 |
+
+This also affects Seconds → Exact frames conversion and rejects requests just
+beyond the maximum 3592-frame duration instead of silently rounding them down.
+Existing authored exact frame counts are unchanged. Existing seconds requests
+already compiled correctly in Python; their browser estimates now agree.
+
+Run `python tests/_plan_duration_parity_test.py` to compare 7,829 duration
+requests with the actual Python helper, including fractional-frame requests,
+decimal tolerance and upper-bound failures. The test also compares six native
+compiled Plans with browser raw/delivered timing and checks exact-frame
+conversion. ComfyUI imports are stubbed, projects are temporary, and no GPU
+execution or project-file writes are required.

--- a/tests/_plan_duration_parity_test.py
+++ b/tests/_plan_duration_parity_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Compare browser timing with the real Python compiler using CPU-only inputs."""
+
+import json
+import pathlib
+import runpy
+import subprocess
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+fixture = runpy.run_path(str(ROOT / "tests" / "_chapter_delivery_unit_test.py"))
+chain = fixture["chain"]
+
+
+def main():
+    durations = [1, 6, 8, 10, 12, 15, 0, -1]
+    durations += [frames / chain.FPS for frames in range(1, chain.MAX_H3_FRAMES + 2)]
+    durations += [(frames + .25) / chain.FPS for frames in range(1, chain.MAX_H3_FRAMES + 1)]
+    durations += [(frames / chain.FPS) + delta
+                  for frames in range(5, chain.MAX_H3_FRAMES + 1, 17)
+                  for delta in [-1e-12, 1e-12, 1e-7]]
+    plans = [
+        {"shots": [{"id": f"s{i}", "prompt": f"Scene {i}", "duration_seconds": seconds}
+                   for i, seconds in enumerate([1, 6, 12], 1)]},
+        {"defaults": {"duration_seconds": 6}, "shots": ["First", "Second"]},
+        {"duration_seconds": 12, "shots": ["First", "Second"]},
+    ]
+    script = """
+      import {h3FrameLength, parsePlanJson, calculatePlanTiming, setShotLengthMode} from './web/h3_chain_plan_core.mjs';
+      import {readFileSync} from 'node:fs';
+      const input = JSON.parse(readFileSync(0, 'utf8'));
+      const lengths = input.durations.map(value => { try { return h3FrameLength(value); } catch { return null; } });
+      const plans = input.plans.flatMap(plan => ['head', 'before'].map(anchorMode => {
+        const result = calculatePlanTiming(parsePlanJson(JSON.stringify(plan)), {anchorMode});
+        return {raw: result.shots.map(s => s.rawFrames), delivered: result.shots.map(s => s.deliveredFrames), total: result.totalFrames};
+      }));
+      const converted = [1, 6, 12].map(duration_seconds => {
+        const shot = {duration_seconds}; setShotLengthMode(shot, 'frames'); return shot.length;
+      });
+      process.stdout.write(JSON.stringify({lengths, plans, converted}));
+    """
+    response = subprocess.run(["node", "--input-type=module", "-e", script], cwd=ROOT,
+                              input=json.dumps({"durations": durations, "plans": plans}),
+                              text=True, capture_output=True, check=True)
+    browser = json.loads(response.stdout)
+    for seconds, actual in zip(durations, browser["lengths"], strict=True):
+        try:
+            expected = chain._h3_frame_length(seconds)
+        except ValueError:
+            expected = None
+        assert actual == expected, (seconds, actual, expected)
+    assert browser["converted"] == [chain._h3_frame_length(s) for s in [1, 6, 12]]
+    with tempfile.TemporaryDirectory() as directory:
+        fixture["folder_paths"].output_directory = directory
+        for offset, (raw, anchor) in enumerate((plan, mode) for plan in plans for mode in ["head", "before"]):
+            compiled = chain._normalize_plan(json.dumps(raw), "duration_parity", 64, 64,
+                                              22, "video", anchor, "disabled", "generated_audio",
+                                              22, 15, 20, 0, 18)
+            expected = {"raw": [s["raw_frames"] for s in compiled["shots"]],
+                        "delivered": [s["delivered_frames"] for s in compiled["shots"]],
+                        "total": sum(s["delivered_frames"] for s in compiled["shots"])}
+            assert browser["plans"][offset] == expected, (raw, anchor, browser["plans"][offset], expected)
+        assert not list(pathlib.Path(directory).iterdir()), "Timing inspection wrote project files"
+    print(f"Python/browser parity: {len(durations)} durations, 6 compiled plans, and exact-frame conversion passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/h3_chain_cancel_reroll.js
+++ b/web/h3_chain_cancel_reroll.js
@@ -1,6 +1,6 @@
 import {app} from "/scripts/app.js";
 import {api} from "/scripts/api.js";
-import {parsePlanJson, planToJson, randomSceneSeed} from "./h3_chain_plan_core.mjs?v=0.7.8";
+import {parsePlanJson, planToJson, randomSceneSeed} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {
     activeSceneFromOutput,
     applySceneReroll,

--- a/web/h3_chain_cancel_reroll_core.mjs
+++ b/web/h3_chain_cancel_reroll_core.mjs
@@ -1,4 +1,4 @@
-import {MAX_SEED} from "./h3_chain_plan_core.mjs?v=0.7.8";
+import {MAX_SEED} from "./h3_chain_plan_core.mjs?v=0.7.9";
 
 function normalizedPositiveInteger(value, label) {
     const number = Number(value);

--- a/web/h3_chain_checkpoint_manager.js
+++ b/web/h3_chain_checkpoint_manager.js
@@ -31,7 +31,7 @@ import {
     parsePlanJson,
     planToJson,
     promptValueToText,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {applyCheckpointRevisionSet} from "./h3_chain_review_core.mjs?v=0.7.7";
 import * as promptCompanionSync from "./h3_prompt_companion_sync.mjs?v=0.7.2";
 import {

--- a/web/h3_chain_plan_core.mjs
+++ b/web/h3_chain_plan_core.mjs
@@ -701,7 +701,9 @@ export function h3FrameLength(seconds) {
         throw new Error("Duration must be a finite positive number.");
     }
     const requested = Math.max(5, Math.ceil(numeric * FPS - 1e-9));
-    const length = requested + ((5 - (requested % 17)) % 17);
+    // JS remainder can be negative; Python modulo in _h3_frame_length cannot.
+    // Always advance to the next valid length, including near the upper bound.
+    const length = requested + ((5 - (requested % 17) + 17) % 17);
     if (length > MAX_H3_FRAMES) {
         throw new Error(
             `Duration rounds to ${length} frames; H3's largest valid length is ${MAX_H3_FRAMES}.`,

--- a/web/h3_chain_plan_editor.js
+++ b/web/h3_chain_plan_editor.js
@@ -31,7 +31,7 @@ import {
     shotLengthMode,
     sharedPrompt,
     visualContextCompositions,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {availableReferenceRecords} from "./h3_reference_preview_core.mjs?v=0.7.3";
 import {
     applySceneAudioOverride,

--- a/web/h3_chain_plan_studio.js
+++ b/web/h3_chain_plan_studio.js
@@ -52,7 +52,7 @@ import {
     visualContextDefaultPartition,
     visualContextMaximumBlocks,
     visualContextPartitionFromBoundaries,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {
     promptRevisionHelp,
     promptRevisionLabel,

--- a/web/h3_chain_review_core.mjs
+++ b/web/h3_chain_review_core.mjs
@@ -12,7 +12,7 @@ import {
     sceneVisualContextLeadSource,
     sceneVisualContextSource,
     sharedPrompt,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 
 const FPS = 24;
 const MAX_H3_FRAMES = 3592;

--- a/web/h3_chain_review_final.js
+++ b/web/h3_chain_review_final.js
@@ -7,7 +7,7 @@ import {
     parsePlanJson,
     planToJson,
     promptValueToText,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import * as promptCompanionSync from "./h3_prompt_companion_sync.mjs?v=0.7.2";
 import {
     refreshRestoredPlanEditors,

--- a/web/h3_chain_rich_scene_prompt_editor.js
+++ b/web/h3_chain_rich_scene_prompt_editor.js
@@ -9,7 +9,7 @@ import {
     promptTextToLines,
     promptValueToText,
     sharedPrompt,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {
     buildPromptAssistantContext,
     makePromptAssistRequest,

--- a/web/h3_chain_scene_prompt_editor.js
+++ b/web/h3_chain_scene_prompt_editor.js
@@ -11,7 +11,7 @@ import {
     promptTextToLines,
     promptValueToText,
     sharedPrompt,
-} from "./h3_chain_plan_core.mjs?v=0.7.8";
+} from "./h3_chain_plan_core.mjs?v=0.7.9";
 import {
     PROMPT_ASSIST_DEFAULT_INSTRUCTIONS,
     PROMPT_ASSIST_MODES,

--- a/web/h3_prompt_assistant_core.mjs
+++ b/web/h3_prompt_assistant_core.mjs
@@ -1,4 +1,4 @@
-import {promptValueToText, sharedPrompt} from "./h3_chain_plan_core.mjs?v=0.7.8";
+import {promptValueToText, sharedPrompt} from "./h3_chain_plan_core.mjs?v=0.7.9";
 
 export const PROMPT_ASSIST_MODES = Object.freeze([
     {id: "rewrite", label: "Rewrite"},


### PR DESCRIPTION
The browser could round requested durations down because JavaScript remainder can be negative. For example, 1 second became 22 frames in Studio while the Python compiler generated 39. Seconds-to-exact-frame conversion could therefore shorten a scene, and requests just beyond the maximum duration could be accepted incorrectly.

Normalize the browser remainder before adding padding and refresh the Plan core import cache keys. Existing exact-frame inputs and Python compilation are unchanged.

Validation:
- Compared 7,829 durations against the actual Python helper, including fractional-frame requests, floating-point boundaries and maximum-length rejection.
- Compared six compiled Plans with browser raw/delivered timing and checked seconds-to-frame conversion; no project files were written.
- Existing Plan editor, Studio, scene-duplication and chapter-resolution JavaScript regressions passed.

The tests use CPU-only native helpers with ComfyUI import stubs. No production project or GPU execution was used.
