### PR TITLE
Add conditional prompt-history commands and restart recovery

### DIFF
--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -108,7 +108,7 @@ from .review_inventory import (
     mark_review_snapshot_decided as _mark_review_snapshot_decided,
     write_review_snapshot as _write_review_snapshot,
 )
-from .prompt_history import PromptHistoryStore
+from .prompt_history import PromptHistoryStore, PromptHistoryConflict
 from .prompt_optimizer import optimize_prompt_payload
 from .run_manager import RunArchiveManager, archive_policy_inputs
 from .asset_store import MAX_DIRECT_ASSET_BINDINGS, RunAssetStore
@@ -30244,9 +30244,13 @@ async def _get_prompt_history(request):
     run_name = request.query.get("run_name", "")
     scene_id = request.query.get("scene_id", "")
     revision = request.query.get("revision", "")
+    operation_id = request.query.get("operation_id", "")
     store = PromptHistoryStore(_output_root())
     try:
-        if revision:
+        if operation_id:
+            payload = await asyncio.to_thread(
+                store.command_status, run_name, scene_id, operation_id)
+        elif revision:
             payload = await asyncio.to_thread(
                 store.get, run_name, scene_id, revision)
         else:
@@ -30276,7 +30280,12 @@ async def _update_prompt_history(request):
         return rejection
     store = PromptHistoryStore(_output_root())
     try:
-        if action == "save":
+        if "command_version" in body:
+            payload = await asyncio.to_thread(
+                _owned_project_mutation, run_name, ownership_proof,
+                "change prompt history", store.command,
+                run_name, body.get("scene_id"), body)
+        elif action == "save":
             payload = await asyncio.to_thread(
                 _owned_project_mutation, run_name, ownership_proof,
                 "change prompt history", store.save_draft,
@@ -30309,11 +30318,15 @@ async def _update_prompt_history(request):
         else:
             return web.json_response(
                 {"error": "Unknown prompt-history action."}, status=400)
+    except PromptHistoryConflict as exc:
+        return web.json_response({"error": str(exc), "code": "h3_prompt_history_changed"}, status=409)
     except ProjectOwnershipError as exc:
         return web.json_response({
             "error": str(exc), "code": "h3_project_read_only",
         }, status=423)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
+    except OSError as exc:
+        return web.json_response({"error": str(exc)}, status=500)
+    except (ValueError, json.JSONDecodeError) as exc:
         return web.json_response({"error": str(exc)}, status=400)
     return web.json_response(payload)
 

--- a/docs/prompt-history-commands.md
+++ b/docs/prompt-history-commands.md
@@ -1,0 +1,101 @@
+# Conditional prompt-history commands
+
+The existing `/minimax_h3_context_loop/prompt-history` endpoint now exposes
+scoped reads and optional conditional writes for companion editors. It does
+not apply text to Plan JSON or alter seeds, shared direction or generated media.
+Existing native editor requests without `command_version` retain their behavior.
+
+## Read and review
+
+GET requires the exact `run_name` and canonical native `scene_id`. Named working
+branches also require `branch_id`; omitting it selects Original (`main`). The
+existing branch request wrapper carries this scope into the store's worker.
+
+- List responses retain format `h3_scene_prompt_history_v1` and add
+  `command_version: 1`, `working_branch_id`, and opaque `history_revision`.
+- `revision=<id>` returns saved text with those same scope/version fields and
+  the current history stamp. Compare the prompt hash with the listed metadata
+  to detect an edit between the two reads.
+- `operation_id=<id>` returns `{history, receipt}`. A null receipt does not
+  authorize a fresh operation: retain and retry the exact original request.
+
+The stamp covers project, scene, working branch, active revision and all revision
+metadata. Legacy edits and execution bookkeeping invalidate it when they change
+that state. Receipt bookkeeping itself is excluded. A copied history in a new
+branch receives a different stamp; receipts from its source cannot be replayed
+or reported as that branch's commands.
+
+## Write
+
+POST uses the existing project ownership headers and `branch_id` routing. Review
+the current list and send the following JSON fields:
+
+| Field | Contract |
+| --- | --- |
+| `command_version` | `1` |
+| `run_name`, `scene_id` | Same exact project and canonical scene as the read |
+| `operation_id` | New 32-character lowercase hexadecimal ID, retained by the caller |
+| `base_revision` | Reviewed 64-character history stamp |
+| `action` | `save`, `fork`, `activate`, `label`, `archive`, or `delete` |
+
+`save` takes `prompt` and optional `parent_revision`, preserving native behavior:
+identical text reactivates its existing revision; otherwise an active/selected
+mutable draft is updated, or an executed parent gets a new child. `fork` takes
+`revision` and `prompt` and always creates a separate child, even for identical
+text or a mutable parent. `activate` takes `revision` and only changes the
+history's active marker. `label` takes `revision` and `label`; `archive` takes
+`revision` and a boolean `archived`; `delete` takes `revision`.
+
+Native text normalization, 200,000-character prompts, 80-character labels and
+archive/delete protections remain in force. Executed text is immutable; active,
+executed and parent revisions cannot be deleted. Loading text into a companion,
+applying it to the workflow, and saving workflow/branch authoring are separate
+operations.
+
+Successful responses contain `{history, receipt, replayed}`. Under the store
+lock, an existing matching operation is checked before its old base stamp.
+Exact retries return the retained receipt and current history without repeating
+the mutation. Reusing an ID with a different request or scope is rejected. A
+changed base produces HTTP 409; ownership denial produces 423; invalid commands
+produce 400. I/O failures produce 500 because a write may already be committed.
+On transport errors, unreadable acknowledgements or 500, query the operation
+status or retry its exact body/ID; never create a new ID for that uncertain edit.
+
+## Persistence and recovery boundaries
+
+Conditional commands stage changed revision records in memory, then atomically
+write `.command-journal.json` with the intended revision files, index and receipt.
+They materialize revision files and the index before removing the journal. Native
+store readers and writers recover a pending journal under the same process lock
+before returning state. Consequently, a read after an interrupted command may
+finish that previously authorized durable intent; ordinary reads create nothing
+when no journal exists. This prevents a mutable prompt file from being exposed
+with its old index hash after a process interruption.
+
+Deletion commits the index/receipt before removing the unreferenced revision
+file; replay also finishes any interrupted file cleanup. Receipts survive process
+restart and are retained in the index. At 1,024 commands per scene history the
+store rejects new conditional commands rather than evicting IDs and risking a
+duplicate retry. Existing receipts remain readable/replayable. A durable receipt
+does not preserve a caller's unsent request: companion clients must retain their
+operation ID and exact body to retry it.
+
+These guarantees target one ComfyUI process using the existing native store lock
+and filesystem atomic replacement. They do not introduce coordination between
+multiple ComfyUI processes sharing one output directory, transactional legacy
+writes, or protection against manual edits to store files. Branch archival or
+removal has its existing native lifecycle.
+
+## Validation
+
+- `_prompt_history_commands_test.py`: concurrent stale authors, immutable and
+  mutable forks, lost acknowledgements, interruption between revision/index
+  replacement, restart recovery, exact retries, and copied/named branch isolation.
+- `_prompt_history_api_test.py`: real route functions with CPU-only ComfyUI stubs,
+  branch echo, revision/status reads, 409 conflicts, interrupted I/O reported as
+  500, recovery reads and the real 423 project ownership guard.
+- Existing `_prompt_history_unit_test.py` and `_prompt_history_js_test.mjs`:
+  legacy draft/executed/archive/delete behavior and native ancestry navigation.
+
+All projects are temporary fixtures. Production workflow validation remains a
+separate integration step; no GPU generation is required by these checks.

--- a/prompt_history.py
+++ b/prompt_history.py
@@ -20,6 +20,7 @@ from typing import Any
 FORMAT = "h3_scene_prompt_history_v1"
 MAX_PROMPT_LENGTH = 200_000
 MAX_LABEL_LENGTH = 80
+MAX_COMMANDS = 1024
 _LOCK = threading.RLock()
 
 
@@ -94,9 +95,31 @@ def _atomic_json(path: str, value: Any) -> None:
             pass
 
 
+def _branch(run):
+    if __package__:
+        from .branch_scope import current_branch
+    else:
+        from branch_scope import current_branch
+    return current_branch(run)
+
+
+def _history_revision(index):
+    value = {key: index.get(key) for key in
+             ("format", "run_name", "scene_id", "active_revision", "revisions")}
+    value["working_branch_id"] = _branch(index["run_name"])
+    return hashlib.sha256(json.dumps(value, sort_keys=True,
+        ensure_ascii=False, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+class PromptHistoryConflict(ValueError):
+    pass
+
+
 class PromptHistoryStore:
     def __init__(self, output_root: str):
         self.output_root = os.path.abspath(output_root)
+        self._pending_command = None
+        self._staged_revisions = {}
 
     def _scene_dir(self, run_name: Any, scene_id: Any) -> tuple[str, str, str]:
         run = _strict_run_name(run_name)
@@ -122,6 +145,7 @@ class PromptHistoryStore:
         }
 
     def _load_index(self, directory: str, run: str, scene: str) -> dict[str, Any]:
+        self._recover_command(directory, run, scene)
         path = os.path.join(directory, "index.json")
         if not os.path.isfile(path):
             return self._empty_index(run, scene)
@@ -153,6 +177,8 @@ class PromptHistoryStore:
 
     def _read_revision(self, directory: str, revision_id: str) -> dict[str, Any]:
         path = self._revision_path(directory, revision_id)
+        if path in self._staged_revisions:
+            return dict(self._staged_revisions[path])
         try:
             with open(path, "r", encoding="utf-8") as handle:
                 value = json.load(handle)
@@ -176,6 +202,9 @@ class PromptHistoryStore:
             default=None)
         return {
             "format": FORMAT,
+            "command_version": 1,
+            "working_branch_id": _branch(index["run_name"]),
+            "history_revision": _history_revision(index),
             "run_name": index["run_name"],
             "scene_id": index["scene_id"],
             "active_revision": active_revision,
@@ -202,7 +231,10 @@ class PromptHistoryStore:
             revision = str(revision_id or "")
             if self._meta(index, revision) is None:
                 raise ValueError("Unknown prompt revision.")
-            return self._read_revision(directory, revision)
+            value = self._read_revision(directory, revision)
+            return {**value, "run_name": run, "scene_id": scene,
+                    "working_branch_id": _branch(run), "command_version": 1,
+                    "history_revision": _history_revision(index)}
 
     def _find_prompt(self, directory: str, index: dict[str, Any],
                      prompt: str) -> dict[str, Any] | None:
@@ -218,8 +250,135 @@ class PromptHistoryStore:
                 return meta
         return None
 
-    def _write_index(self, directory: str, index: dict[str, Any]) -> None:
+    def _recover_command(self, directory, run, scene):
+        path = os.path.join(directory, ".command-journal.json")
+        if not os.path.isfile(path):
+            return
+        with open(path, "r", encoding="utf-8") as handle:
+            journal = json.load(handle)
+        if not isinstance(journal, dict):
+            raise ValueError("The pending prompt-history journal is invalid.")
+        index, revisions = journal.get("index"), journal.get("revisions")
+        if (not isinstance(index, dict) or index.get("format") != FORMAT
+                or index.get("run_name") != run or index.get("scene_id") != scene
+                or not isinstance(index.get("revisions"), list) or not isinstance(revisions, dict)):
+            raise ValueError("The pending prompt-history journal is invalid.")
+        targets = []
+        for revision_id, value in revisions.items():
+            target = self._revision_path(directory, revision_id)
+            if not isinstance(value, dict) or value.get("id") != revision_id:
+                raise ValueError("The pending prompt-history revision is invalid.")
+            targets.append((target, value))
+        for target, value in targets:
+            _atomic_json(target, value)
         _atomic_json(os.path.join(directory, "index.json"), index)
+        os.unlink(path)
+
+    def _write_revision(self, path, value):
+        if self._pending_command:
+            self._staged_revisions[path] = dict(value)
+        else:
+            _atomic_json(path, value)
+
+    def _write_index(self, directory: str, index: dict[str, Any]) -> None:
+        pending = self._pending_command
+        if pending:
+            # Commit the receipt with the index change, not in a later write.
+            # A lost acknowledgement can never create a second fork on retry.
+            revision_id = (index.get("active_revision") if pending["action"] in
+                           ("save", "fork", "activate") else pending["revision"])
+            meta = self._meta(index, revision_id)
+            receipt = {**pending, "result_revision": revision_id,
+                       "result_prompt_sha256": meta.get("prompt_sha256") if meta else None,
+                       "after_revision": _history_revision(index), "committed_at": _timestamp()}
+            index.setdefault("command_receipts", {})[pending["operation_id"]] = receipt
+        if pending:
+            # The journal is the durable intent. All native readers/writers
+            # recover it under _LOCK before observing an index or revision.
+            journal = {"index": index, "revisions": {
+                os.path.basename(path)[:-5]: value
+                for path, value in self._staged_revisions.items()}}
+            _atomic_json(os.path.join(directory, ".command-journal.json"), journal)
+            self._recover_command(directory, index["run_name"], index["scene_id"])
+            self._staged_revisions = {}
+        else:
+            _atomic_json(os.path.join(directory, "index.json"), index)
+
+    def command_status(self, run_name, scene_id, operation_id):
+        with _LOCK:
+            directory, run, scene = self._scene_dir(run_name, scene_id)
+            index = self._load_index(directory, run, scene)
+            receipt = index.get("command_receipts", {}).get(str(operation_id))
+            if receipt and (receipt.get("run_name"), receipt.get("scene_id"), receipt.get("working_branch_id")) != (run, scene, _branch(run)):
+                receipt = None
+            return {"history": self._public_index(index), "receipt": receipt}
+
+    def command(self, run_name, scene_id, command):
+        """Conditional, idempotent authoring. Existing native writers share _LOCK."""
+        if not isinstance(command, dict) or command.get("command_version") != 1:
+            raise ValueError("Unsupported prompt-history command version.")
+        action = command.get("action")
+        if action not in ("save", "fork", "activate", "label", "archive", "delete"):
+            raise ValueError("Unknown prompt-history command.")
+        operation = str(command.get("operation_id") or "")
+        if re.fullmatch(r"[0-9a-f]{32}", operation) is None:
+            raise ValueError("A 32-character operation ID is required.")
+        expected = command.get("base_revision")
+        if not isinstance(expected, str) or not re.fullmatch(r"[0-9a-f]{64}", expected):
+            raise ValueError("Review the current prompt history before changing it.")
+        request = {key: command.get(key) for key in
+                   ("action", "base_revision", "revision", "parent_revision", "prompt", "label", "archived")}
+        fingerprint = hashlib.sha256(json.dumps(request, sort_keys=True,
+            ensure_ascii=False, separators=(",", ":")).encode("utf-8")).hexdigest()
+        with _LOCK:
+            directory, run, scene = self._scene_dir(run_name, scene_id)
+            index = self._load_index(directory, run, scene)
+            receipt = index.get("command_receipts", {}).get(operation)
+            if receipt:
+                if (receipt.get("run_name"), receipt.get("scene_id"), receipt.get("working_branch_id")) != (run, scene, _branch(run)):
+                    raise ValueError("This operation belongs to a different project, scene or branch.")
+                if receipt["request_sha256"] != fingerprint:
+                    raise ValueError("This operation ID was already used for a different command.")
+                if action == "delete":
+                    # The index/receipt commit precedes file cleanup. Finish a
+                    # cleanup interrupted by a crash without repeating the edit.
+                    try:
+                        os.unlink(self._revision_path(directory, str(command.get("revision"))))
+                    except FileNotFoundError:
+                        pass
+                return {"history": self._public_index(index), "receipt": receipt, "replayed": True}
+            if _history_revision(index) != expected:
+                raise PromptHistoryConflict("Prompt history changed. Reload and review it before retrying.")
+            if len(index.get("command_receipts", {})) >= MAX_COMMANDS:
+                raise ValueError("This scene reached its retained history-command limit; no receipts were discarded.")
+            self._pending_command = {"operation_id": operation, "action": action,
+                "run_name": run, "scene_id": scene, "working_branch_id": _branch(run),
+                "revision": command.get("revision"), "request_sha256": fingerprint,
+                "before_revision": expected}
+            try:
+                if action == "save":
+                    self.save_draft(run, scene, command.get("prompt", ""), command.get("parent_revision"))
+                elif action == "fork":
+                    parent = str(command.get("revision") or "")
+                    if self._meta(index, parent) is None:
+                        raise ValueError("The parent prompt revision no longer exists.")
+                    self._create(directory, index, _normalized_prompt(command.get("prompt", "")), parent)
+                elif action == "activate":
+                    self.activate(run, scene, command.get("revision"))
+                elif action == "label":
+                    self.set_label(run, scene, command.get("revision"), command.get("label", ""))
+                elif action == "archive":
+                    if not isinstance(command.get("archived"), bool):
+                        raise ValueError("Archived must be a boolean.")
+                    self.set_archived(run, scene, command.get("revision"), command["archived"])
+                else:
+                    self.delete_draft(run, scene, command.get("revision"))
+            finally:
+                self._pending_command = None
+                self._staged_revisions = {}
+            result = self.command_status(run, scene, operation)
+            result["replayed"] = False
+            return result
 
     def _create(self, directory: str, index: dict[str, Any], prompt: str,
                 parent_id: str | None) -> dict[str, Any]:
@@ -237,7 +396,7 @@ class PromptHistoryStore:
             "prompt_sha256": _prompt_hash(prompt),
         }
         revision = {"format": FORMAT, **meta, "prompt": prompt}
-        _atomic_json(self._revision_path(directory, meta["id"]), revision)
+        self._write_revision(self._revision_path(directory, meta["id"]), revision)
         index["revisions"].append(meta)
         index["active_revision"] = meta["id"]
         self._write_index(directory, index)
@@ -255,7 +414,7 @@ class PromptHistoryStore:
                     exact["archived_at"] = None
                     revision = self._read_revision(directory, exact["id"])
                     revision["archived_at"] = None
-                    _atomic_json(
+                    self._write_revision(
                         self._revision_path(directory, exact["id"]), revision)
                 index["active_revision"] = exact["id"]
                 self._write_index(directory, index)
@@ -281,7 +440,7 @@ class PromptHistoryStore:
                     "prompt_sha256": parent_meta["prompt_sha256"],
                     "prompt": prompt,
                 })
-                _atomic_json(self._revision_path(directory, parent), revision)
+                self._write_revision(self._revision_path(directory, parent), revision)
                 index["active_revision"] = parent
                 self._write_index(directory, index)
             else:
@@ -306,7 +465,7 @@ class PromptHistoryStore:
             if meta.get("archived_at"):
                 meta["archived_at"] = None
                 value["archived_at"] = None
-                _atomic_json(self._revision_path(directory, revision), value)
+                self._write_revision(self._revision_path(directory, revision), value)
             index["active_revision"] = revision
             self._write_index(directory, index)
             return {"history": self._public_index(index), "revision": value}
@@ -324,7 +483,7 @@ class PromptHistoryStore:
             revision = self._read_revision(directory, revision_id)
             meta["label"] = label
             revision["label"] = label
-            _atomic_json(
+            self._write_revision(
                 self._revision_path(directory, revision_id), revision)
             self._write_index(directory, index)
             return {
@@ -350,7 +509,7 @@ class PromptHistoryStore:
             archived_at = _timestamp() if should_archive else None
             meta["archived_at"] = archived_at
             revision["archived_at"] = archived_at
-            _atomic_json(
+            self._write_revision(
                 self._revision_path(directory, revision_id), revision)
             self._write_index(directory, index)
             return {
@@ -422,7 +581,7 @@ class PromptHistoryStore:
                 "execution_count": meta["execution_count"],
                 "updated_at": now,
             })
-            _atomic_json(self._revision_path(directory, meta["id"]), revision)
+            self._write_revision(self._revision_path(directory, meta["id"]), revision)
             index["active_revision"] = meta["id"]
             self._write_index(directory, index)
             return {"history": self._public_index(index), "revision": revision}

--- a/tests/_prompt_history_api_test.py
+++ b/tests/_prompt_history_api_test.py
@@ -1,0 +1,76 @@
+"""Real routes with CPU-only Comfy stubs, ownership and named-branch scope."""
+import asyncio
+import json
+import pathlib
+import runpy
+import sys
+import tempfile
+import uuid
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+chain = runpy.run_path(str(ROOT / "tests/_chapter_delivery_unit_test.py"))["chain"]
+
+class Request:
+    def __init__(self, body=None, **query):
+        self.query = query
+        self.method = "GET" if body is None else "POST"
+        self.headers = {}
+        self.body = body
+    async def json(self):
+        return self.body
+
+async def main():
+    with tempfile.TemporaryDirectory() as temporary:
+        chain._output_root = lambda: temporary
+        branch = "1" * 32
+        path = pathlib.Path(temporary, "h3_chains", "film", "branches", branch)
+        path.mkdir(parents=True); (path / "branch.json").write_text("{}")
+        read = await chain._get_prompt_history(Request(run_name="film", scene_id="one", branch_id=branch))
+        state = json.loads(read.text)
+        assert state["working_branch_id"] == branch and state["revisions"] == []
+        body = dict(command_version=1, action="save", operation_id=uuid.uuid4().hex,
+                    base_revision=state["history_revision"], run_name="film", scene_id="one", prompt="Named branch draft")
+        result = await chain._update_prompt_history(Request(body, branch_id=branch))
+        assert result.status == 200, result.text
+        saved = json.loads(result.text)
+        assert saved["history"]["working_branch_id"] == branch
+        assert json.loads((await chain._get_prompt_history(Request(run_name="film", scene_id="one"))).text)["revisions"] == []
+        revision = saved["history"]["active_revision"]
+        content = json.loads((await chain._get_prompt_history(Request(run_name="film", scene_id="one", branch_id=branch, revision=revision))).text)
+        assert content["prompt"] == body["prompt"] and content["working_branch_id"] == branch
+        retry = await chain._update_prompt_history(Request(body, branch_id=branch))
+        assert json.loads(retry.text)["replayed"]
+        status = await chain._get_prompt_history(Request(run_name="film", scene_id="one", branch_id=branch, operation_id=body["operation_id"]))
+        assert json.loads(status.text)["receipt"]["operation_id"] == body["operation_id"]
+        stale = await chain._update_prompt_history(Request({**body, "operation_id": uuid.uuid4().hex}, branch_id=branch))
+        assert stale.status == 409, stale.text
+        # A write may have committed before an I/O error. Report 500, retain
+        # its receipt, and allow a status read to finish journal recovery.
+        module = sys.modules[chain.PromptHistoryStore.__module__]
+        original_write = module._atomic_json
+        interrupted = {**body, "operation_id": uuid.uuid4().hex,
+                       "base_revision": saved["history"]["history_revision"],
+                       "prompt": "Recovered through API"}
+        def interrupted_write(path, value):
+            original_write(path, value)
+            if path.endswith(revision + ".json"):
+                raise OSError("Interrupted prompt write")
+        module._atomic_json = interrupted_write
+        try:
+            result = await chain._update_prompt_history(Request(interrupted, branch_id=branch))
+            assert result.status == 500, result.text
+        finally:
+            module._atomic_json = original_write
+        recovered = json.loads((await chain._get_prompt_history(Request(
+            run_name="film", scene_id="one", branch_id=branch,
+            operation_id=interrupted["operation_id"]))).text)
+        assert recovered["receipt"]["operation_id"] == interrupted["operation_id"]
+        # Use the real ownership guard: a non-owner cannot write history.
+        chain.claim_project_ownership(temporary, "film", "workflow-owner-a-1234567890", "Owner")
+        denied = await chain._update_prompt_history(Request({**body, "operation_id": uuid.uuid4().hex}, branch_id=branch))
+        assert denied.status == 423, denied.text
+        after = json.loads((await chain._get_prompt_history(Request(run_name="film", scene_id="one", branch_id=branch))).text)
+        assert after["history_revision"] == recovered["history"]["history_revision"]
+    print("Prompt history API: scope echo, revision reads, retries, 409 conflicts and 423 ownership passed")
+
+asyncio.run(main())

--- a/tests/_prompt_history_commands_test.py
+++ b/tests/_prompt_history_commands_test.py
@@ -1,0 +1,139 @@
+"""Conditional prompt writes, durable retries and named-branch isolation."""
+import concurrent.futures
+import hashlib
+import json
+import pathlib
+import shutil
+import tempfile
+import uuid
+
+import prompt_history as history
+from branch_scope import branch_scope
+
+def command(store, root, scene, action, **fields):
+    return dict(command_version=1, operation_id=uuid.uuid4().hex,
+                base_revision=store.list(root, scene)["history_revision"], action=action, **fields)
+
+with tempfile.TemporaryDirectory() as temporary:
+    store = history.PromptHistoryStore(temporary)
+    empty = store.list("film", "scene")
+    assert empty["command_version"] == 1 and empty["working_branch_id"] == "main"
+    assert not list(pathlib.Path(temporary).rglob("*.json"))
+    first = command(store, "film", "scene", "save", prompt="First draft")
+    out = store.command("film", "scene", first)
+    root = out["history"]["active_revision"]
+    assert store.command("film", "scene", first)["replayed"]
+    assert len(store.list("film", "scene")["revisions"]) == 1
+    try:
+        store.command("film", "scene", {**first, "prompt": "Changed request"})
+        raise AssertionError("Reused ID accepted different contents")
+    except ValueError:
+        pass
+    stale = command(store, "film", "scene", "label", revision=root, label="Stale label")
+    store.mark_executed("film", "scene", "First draft")
+    try:
+        store.command("film", "scene", stale)
+        raise AssertionError("Execution failed to invalidate preview")
+    except history.PromptHistoryConflict:
+        pass
+    fork = command(store, "film", "scene", "fork", revision=root, prompt="Child draft")
+    child = store.command("film", "scene", fork)["history"]["active_revision"]
+    assert store.get("film", "scene", root)["prompt"] == "First draft"
+    assert store.get("film", "scene", child)["parent_id"] == root
+    # Fork a mutable draft without rewriting it or collapsing identical text.
+    newer = command(store, "film", "scene", "fork", revision=child, prompt="Child draft")
+    new_id = store.command("film", "scene", newer)["history"]["active_revision"]
+    assert new_id != child
+    # A crash after the index commit, before returning, retains the receipt.
+    crashing = command(store, "film", "scene", "fork", revision=new_id, prompt="Crash-safe child")
+    original_write = history._atomic_json
+    def crash_after_commit(path, value):
+        original_write(path, value)
+        if path.endswith("index.json"):
+            raise OSError("Simulated lost acknowledgement")
+    history._atomic_json = crash_after_commit
+    try:
+        store.command("film", "scene", crashing)
+        raise AssertionError("Missing simulated failure")
+    except OSError:
+        pass
+    finally:
+        history._atomic_json = original_write
+    count = len(store.list("film", "scene")["revisions"])
+    assert history.PromptHistoryStore(temporary).command("film", "scene", crashing)["replayed"]
+    assert len(store.list("film", "scene")["revisions"]) == count
+    # A process can stop after replacing a mutable prompt file but before its
+    # index/receipt. A new store must roll forward the durable intent on read.
+    mutable_id = store.list("film", "scene")["active_revision"]
+    interrupted = command(store, "film", "scene", "save", prompt="Recovered mutable text")
+    def crash_between_files(path, value):
+        original_write(path, value)
+        if path.endswith(mutable_id + ".json"):
+            raise OSError("Simulated process interruption before index")
+    history._atomic_json = crash_between_files
+    try:
+        store.command("film", "scene", interrupted)
+        raise AssertionError("Missing simulated interruption")
+    except OSError:
+        pass
+    finally:
+        history._atomic_json = original_write
+    restarted = history.PromptHistoryStore(temporary)
+    recovered = restarted.list("film", "scene")
+    text = restarted.get("film", "scene", mutable_id)["prompt"]
+    assert text == "Recovered mutable text"
+    assert next(item for item in recovered["revisions"] if item["id"] == mutable_id)["prompt_sha256"] == hashlib.sha256(text.encode()).hexdigest()
+    assert restarted.command_status("film", "scene", interrupted["operation_id"])["receipt"]
+    assert restarted.command("film", "scene", interrupted)["replayed"]
+    assert len(restarted.list("film", "scene")["revisions"]) == count
+    assert not list(pathlib.Path(temporary).rglob(".command-journal.json"))
+    # Two authors reviewing the same index: exactly one change can commit.
+    left = command(store, "film", "scene", "label", revision=root, label="Left")
+    right = {**left, "operation_id": uuid.uuid4().hex, "label": "Right"}
+    def apply(value):
+        try:
+            history.PromptHistoryStore(temporary).command("film", "scene", value)
+            return True
+        except history.PromptHistoryConflict:
+            return False
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        assert sorted(pool.map(apply, [left, right])) == [False, True]
+    # Named branch reads and commands cannot use Original's review stamp.
+    branch = "1" * 32
+    directory = pathlib.Path(temporary, "h3_chains", "film", "branches", branch)
+    directory.mkdir(parents=True); (directory / "branch.json").write_text("{}")
+    with branch_scope("film", branch):
+        assert store.list("film", "scene")["working_branch_id"] == branch
+        assert store.list("film", "scene")["revisions"] == []
+        try:
+            store.command("film", "scene", first)
+            raise AssertionError("Original stamp accepted in named branch")
+        except history.PromptHistoryConflict:
+            pass
+        separate = command(store, "film", "scene", "save", prompt="Branch prompt")
+        store.command("film", "scene", separate)
+    assert store.get("film", "scene", root)["prompt"] == "First draft"
+    assert store.command_status("film", "scene", separate["operation_id"])["receipt"] is None
+    copied_branch = "2" * 32
+    copied = pathlib.Path(temporary, "h3_chains", "film", "branches", copied_branch)
+    copied.mkdir(); (copied / "branch.json").write_text("{}")
+    shutil.copytree(pathlib.Path(temporary, "h3_chains", "film", "prompt_history"), copied / "prompt_history")
+    with branch_scope("film", copied_branch):
+        assert store.command_status("film", "scene", first["operation_id"])["receipt"] is None
+        try:
+            store.command("film", "scene", first)
+            raise AssertionError("Copied Original receipt replayed in another branch")
+        except ValueError as error:
+            assert "different project, scene or branch" in str(error)
+    # All native restrictions still apply, including executed and parent deletion.
+    for revision in (root, child):
+        try:
+            store.command("film", "scene", command(store, "film", "scene", "delete", revision=revision))
+            raise AssertionError("Protected revision deleted")
+        except ValueError:
+            pass
+    store.command("film", "scene", command(store, "film", "scene", "archive", revision=root, archived=True))
+    assert store.get("film", "scene", root)["archived_at"]
+    store.command("film", "scene", command(store, "film", "scene", "activate", revision=root))
+    assert not store.get("film", "scene", root)["archived_at"]
+print("Prompt history commands: conditional writes, forks, durable retries, races and branches passed")


### PR DESCRIPTION
Companion editors currently cannot verify which working branch supplied prompt history or safely retry a save after losing its response. This adds scoped history reads and optional conditional commands to the existing endpoint. For example, retrying an acknowledged-on-disk fork with the same operation ID returns its receipt instead of creating another child.

List/revision responses echo the project, scene and working branch, plus a history revision stamp. Version 1 commands support save, explicit fork, activate, label, archive and delete with ownership checks, stale-state rejection and durable receipts. Legacy editor requests retain their behavior. Loading or activating saved history does not apply its text to Plan JSON.

A recovery journal commits revision files, index and receipt together as durable intent. Native store reads/writes finish an interrupted command before returning state, including a crash after a mutable prompt file changes but before its index. I/O errors return 500 so clients retain the exact request and check its receipt. Receipts are not evicted; new commands stop at 1,024 per scene history. The protocol document describes restart, copied-branch and single-process boundaries.

Validation: existing Python history and JavaScript ancestry tests pass; new store tests cover concurrent authors, immutable/mutable forks, interruptions between file writes, restart/retry and named/copied branch isolation. Tests of the real HTTP handlers with CPU-only ComfyUI stubs cover scope echo, read/status/retry, 409 conflicts, 500 interrupted writes and the real 423 ownership guard. Python compilation and diff checks pass. All projects are temporary fixtures; production workflow validation remains pending.

This draft targets nightly and supports SceneWeaver's saved prompt history workspace. It does not include or depend on the other open SceneWeaver integration PRs.
