### PR TITLE
Add reviewed media library commands and recoverable picture creation

### DIFF
--- a/asset_capture.py
+++ b/asset_capture.py
@@ -1,0 +1,76 @@
+"""Reviewed saved-clip frame capture using native extraction and catalog rules."""
+from __future__ import annotations
+
+import copy
+import os
+import shutil
+
+if __package__:
+    from . import project_assets as native
+    from .asset_copy import _hash, _stamp, command_staged
+else:
+    import project_assets as native
+    from asset_copy import _hash, _stamp, command_staged
+
+FIELDS = ("command_version", "project", "operation_id", "action", "base_revision",
+          "asset_id", "source", "time_seconds", "tag", "folder_id", "preview_revision")
+
+
+def inspect_capture(store, project, request, resolve):
+    catalog = store.load(project)
+    record = resolve(project, request)
+    folder = str(request.get("folder_id") or "")
+    if folder and folder not in {item["id"] for item in catalog["folders"]}:
+        raise ValueError("The capture folder no longer exists.")
+    tag = native._safe_tag(request.get("tag"), "capture")
+    value = {"project": catalog["project"], "base_revision": _stamp(catalog),
+        "source": copy.deepcopy(request["source"]), "time_seconds": record["time_seconds"],
+        "tag": tag, "folder_id": folder, "copyable": len(catalog["assets"]) < native.MAX_CATALOG_ASSETS,
+        "issue": "The asset catalog is full." if len(catalog["assets"]) >= native.MAX_CATALOG_ASSETS else "",
+        "source_sha256": record["sha256"], "metadata_sha256": record["metadata_sha256"]}
+    value["preview_revision"] = _hash(value)
+    return value
+
+
+def command_capture(store, project, body, resolve, extract, commit_guard):
+    def snapshot(store, project, request):
+        preview = inspect_capture(store, project, request, resolve)
+        catalog = store.load(project)
+        if _stamp(catalog) != preview["base_revision"]:
+            raise native.ProjectAssetConflictError("The library changed during frame review.")
+        return preview, catalog, None
+
+    def stage(store, directory, request, catalog, _source, preview):
+        record = resolve(project, request)
+        if record["sha256"] != preview["source_sha256"] or record["metadata_sha256"] != preview["metadata_sha256"]:
+            raise native.ProjectAssetConflictError("The saved clip changed after frame review.")
+        scratch = os.path.join(directory, "stage")
+        shutil.rmtree(scratch, ignore_errors=True)
+        os.makedirs(scratch, exist_ok=True)
+        picture = os.path.join(scratch, "capture.png")
+        try:
+            extract(record["path"], record["time_seconds"], picture)
+        except RuntimeError as exc:
+            raise ValueError(str(exc)) from exc
+        if inspect_capture(store, project, request, resolve)["preview_revision"] != request["preview_revision"]:
+            raise native.ProjectAssetConflictError("The saved clip or library changed during capture.")
+        staged = native.ProjectAssetStore(os.path.join(scratch, "input"), os.path.join(scratch, "output"))
+        staged_dir, _ = staged._project_dir(project)
+        native._atomic_json(os.path.join(staged_dir, "catalog.json"), catalog)
+        result = staged.import_file(project, picture, role="picture", tag=request["tag"],
+            folder_id=request["folder_id"], source_kind="frame_capture", original_name="frame_capture.png")
+        entry = result["asset"]
+        relative = entry["relative_path"]
+        entry["relative_path"] = "images/%s_%s" % (request["operation_id"], os.path.basename(relative))
+        entry["input_path"] = "h3_projects/%s/%s" % (project, entry["relative_path"])
+        entry["source_origin"] = {"project": project, "kind": "saved_frame",
+            **copy.deepcopy(request["source"]), "time_seconds": record["time_seconds"],
+            "sha256": record["sha256"], "metadata_sha256": record["metadata_sha256"]}
+        entry["transform"] = {"kind": "frame_capture", "operation_id": request["operation_id"],
+            "time_seconds": record["time_seconds"]}
+        return {"request": request, "phase": "prepared", "assets": [entry], "files": [{
+            "staged": os.path.relpath(os.path.join(staged_dir, relative), directory),
+            "relative_path": entry["relative_path"], "sha256": entry["sha256"]}]}
+
+    return command_staged(store, project, body, "asset_capture", FIELDS, snapshot, stage,
+        commit_guard=commit_guard)

--- a/asset_copy.py
+++ b/asset_copy.py
@@ -1,0 +1,268 @@
+"""Reviewed cross-project copies with private staging and one catalog commit.
+
+The native importer still defines tags, track bindings and media metadata. Its
+intermediate saves happen in a private store; only the completed group becomes
+visible in the destination. A prepared operation retains frozen bytes for retry.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import shutil
+
+if __package__:
+    from . import project_assets as native
+else:
+    import project_assets as native
+
+FIELDS = ("command_version", "project", "operation_id", "action", "base_revision",
+          "source_project", "asset_id", "enabled", "folder_id", "preview_revision")
+
+
+def _hash(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, ensure_ascii=False,
+        separators=(",", ":")).encode()).hexdigest()
+
+
+def _stamp(catalog):
+    return str(catalog.get("storage_revision") or "empty")
+
+
+def _snapshot(store, project, source_project, asset_id, enabled, folder_id):
+    target = store.load(project)
+    source = store.load(source_project)
+    if source["project"] == target["project"]:
+        raise ValueError("Choose another project; use Duplicate for a local asset.")
+    if not isinstance(enabled, bool):
+        raise ValueError("Choose whether the copied asset is enabled.")
+    if folder_id and folder_id not in {item["id"] for item in target["folders"]}:
+        raise ValueError("The destination folder no longer exists.")
+    root = next((item for item in source["assets"] if item["id"] == asset_id), None)
+    if not root:
+        raise ValueError("The source asset no longer exists.")
+    tracks = native.audio_track_bindings((root.get("options") or {}).get("audio_tracks"), source["assets"]) or {}
+    ids = list(dict.fromkeys([asset_id, *filter(None, tracks.values())]))
+    entries = [next(item for item in source["assets"] if item["id"] == value) for value in ids]
+    identities = []
+    for entry in entries:
+        try:
+            stat = os.stat(store._asset_path(source_project, entry))
+        except OSError as exc:
+            raise ValueError("Source media is unavailable: %s" % entry.get("tag", entry["id"])) from exc
+        identities.append([entry["id"], entry.get("sha256"), stat.st_size, stat.st_mtime_ns])
+    conflict = bool(enabled and root["role"] == "source_track" and any(
+        item["role"] == "source_track" and item.get("enabled", True) for item in target["assets"]))
+    preview = {"project": target["project"], "source_project": source["project"],
+        "asset_id": asset_id, "base_revision": _stamp(target), "source_revision": _stamp(source),
+        "enabled": enabled, "folder_id": folder_id, "assets": copy.deepcopy(entries),
+        "copyable": not conflict and len(target["assets"]) + len(entries) <= native.MAX_CATALOG_ASSETS,
+        "issue": "The destination already has an enabled Source track. Copy this one disabled." if conflict else
+            "The destination asset catalog is full." if len(target["assets"]) + len(entries) > native.MAX_CATALOG_ASSETS else ""}
+    preview["preview_revision"] = _hash([preview, identities])
+    return preview, target, source
+
+
+def preview_copy(store, project, source_project, asset_id, enabled=True, folder_id=""):
+    return _snapshot(store, project, source_project, str(asset_id), enabled, str(folder_id))[0]
+
+
+def _directory(store, project, operation):
+    if not re.fullmatch(r"[0-9a-f]{32}", str(operation)):
+        raise ValueError("A 32-character copy operation ID is required.")
+    directory, _ = store._project_dir(project)
+    path = os.path.realpath(os.path.join(directory, ".library_copies", operation))
+    if not native._inside(directory, path):
+        raise ValueError("Copy staging path escapes the project.")
+    return path
+
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return None
+
+
+def pending_copy(store, project, operation):
+    job = _read(os.path.join(_directory(store, project, operation), "operation.json"))
+    if not job or job["request"].get("project") != project or job["phase"] == "rejected":
+        return None
+    return {"operation_id": operation, "action": "asset_copy", "phase": job["phase"],
+            "request": job["request"]}
+
+
+def pending_copies(store, project, catalog):
+    directory, _ = store._project_dir(project)
+    root = os.path.join(directory, ".library_copies")
+    if not os.path.isdir(root):
+        return []
+    result = []
+    for operation in sorted(os.listdir(root)):
+        if not re.fullmatch(r"[0-9a-f]{32}", operation) or operation in (catalog.get("library_receipts") or {}):
+            continue
+        item = pending_copy(store, project, operation)
+        if item:
+            result.append({key: value for key, value in item.items() if key != "request"})
+    return result
+
+
+def finish_copy(store, project, receipt):
+    """A committed receipt proves publication no longer needs private staging.
+
+    A status read holds the catalog lock. It must not take the operation lock
+    in reverse order. After commit, retries follow the receipt path and no
+    publisher can still need the staging bytes.
+    """
+    if receipt.get("project") != project or receipt.get("action") != "asset_copy":
+        return
+    directory = _directory(store, project, receipt["operation_id"])
+    job = _read(os.path.join(directory, "operation.json"))
+    if job and _hash(job["request"]) == receipt.get("request_sha256"):
+        shutil.rmtree(os.path.join(directory, "stage"), ignore_errors=True)
+
+
+def _stage(store, directory, request, target, source, preview):
+    scratch = os.path.join(directory, "stage")
+    shutil.rmtree(scratch, ignore_errors=True)
+    source_name, target_name = source["project"], target["project"]
+    entries = preview["assets"]
+
+    class StagedStore(native.ProjectAssetStore):
+        imported = 0
+
+        def load(self, project, **kwargs):
+            return copy.deepcopy(source) if project == source_name else super().load(project, **kwargs)
+
+        def asset(self, project, asset_id):
+            if project != source_name:
+                return super().asset(project, asset_id)
+            entry = next(item for item in entries if item["id"] == asset_id)
+            return copy.deepcopy(entry), store._asset_path(source_name, entry)
+
+        def import_file(self, project, path, **kwargs):
+            origin = entries[self.imported]
+            if self.imported == 0 and not request["enabled"] and kwargs.get("role") == "source_track":
+                kwargs["role"] = "audio_reference" if origin["kind"] == "audio" else "video"
+            result = super().import_file(project, path, **kwargs)
+            entry = result["asset"]
+            if origin.get("sha256") and entry["sha256"] != origin["sha256"]:
+                raise native.ProjectAssetConflictError("Source media changed after review.")
+            self.imported += 1
+            return result
+
+    staged = StagedStore(os.path.join(scratch, "input"), os.path.join(scratch, "output"))
+    staged_directory, _ = staged._project_dir(target_name)
+    if _stamp(target) != "empty":
+        native._atomic_json(os.path.join(staged_directory, "catalog.json"), target)
+    result = staged.import_project_asset(target_name, source_name, request["asset_id"])
+    staged.update(target_name, result["asset"]["id"], {"role": entries[0]["role"], "enabled": request["enabled"]})
+    final = staged.load(target_name)
+    created = final["assets"][len(target["assets"]):]
+    files = []
+    for entry, origin in zip(created, entries, strict=True):
+        relative = entry["relative_path"]
+        group, basename = relative.split("/", 1)
+        entry["relative_path"] = "%s/%s_%s" % (group, request["operation_id"], basename)
+        entry["input_path"] = "h3_projects/%s/%s" % (target_name, entry["relative_path"])
+        entry["folder_id"] = request["folder_id"]
+        entry["source_origin"] = {"project": source_name, "asset_id": origin["id"],
+            **{key: copy.deepcopy(origin[key]) for key in ("parent_asset_id", "transform", "source_origin", "folder_id", "sha256", "source_kind") if key in origin}}
+        files.append({"staged": os.path.relpath(os.path.join(staged_directory, relative), directory),
+                      "relative_path": entry["relative_path"], "sha256": entry["sha256"]})
+    if preview_copy(store, target_name, source_name, request["asset_id"], request["enabled"], request["folder_id"])["preview_revision"] != request["preview_revision"]:
+        raise native.ProjectAssetConflictError("Source or destination changed while copying. Review again.")
+    return {"request": request, "phase": "prepared", "assets": created, "files": files}
+
+
+def _publish_files(store, project, directory, job):
+    for root in (store._project_dir(project)[0], store._backup_dir(project)[0]):
+        for item in job["files"]:
+            source = os.path.realpath(os.path.join(directory, item["staged"]))
+            destination = os.path.realpath(os.path.join(root, item["relative_path"]))
+            if not native._inside(directory, source) or not native._inside(root, destination):
+                raise ValueError("Copy media path escapes its store.")
+            if os.path.isfile(destination):
+                if native._file_sha256(destination) != item["sha256"]:
+                    raise ValueError("Copy destination media changed; it was not overwritten.")
+                continue
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            temporary = destination + ".copy.tmp"
+            shutil.copy2(source, temporary)
+            if native._file_sha256(temporary) != item["sha256"]:
+                raise ValueError("Staged media failed its SHA-256 check.")
+            os.replace(temporary, destination)
+
+
+@native._project_mutation
+def _publish(store, project, request, job):
+    catalog = store.load(project)
+    if _stamp(catalog) != request["base_revision"]:
+        raise native.ProjectAssetConflictError("The destination library changed. Refresh and review again.")
+    if len(catalog.get("library_receipts") or {}) >= 1024:
+        raise ValueError("The retained library-command limit was reached.")
+    store._library_command = {"operation_id": request["operation_id"], "project": project,
+        "action": "asset_copy", "request_sha256": _hash(request), "before_revision": request["base_revision"],
+        "source_project": request["source_project"], "source_asset_id": request["asset_id"],
+        "asset_ids_before": [item["id"] for item in catalog["assets"]],
+        "folder_ids_before": [item["id"] for item in catalog["folders"]]}
+    try:
+        catalog["assets"].extend(copy.deepcopy(job["assets"]))
+        store._save_catalog(catalog)
+    finally:
+        store._library_command = None
+
+
+def command_copy(store, project, body):
+    project = native._safe_project(project)
+    request = {key: body.get(key) for key in FIELDS}
+    if request["project"] != project or request["command_version"] != 1 or request["action"] != "asset_copy":
+        raise ValueError("Copy request does not match this project or command version.")
+    directory = _directory(store, project, request["operation_id"])
+    path = os.path.join(directory, "operation.json")
+    # Operation lock first, then brief target commit lock. No source/target
+    # pair of project locks is held while copying, including reciprocal imports.
+    with native._catalog_lock(path), native._catalog_file_lock(path):
+        saved = (store.load(project).get("library_receipts") or {}).get(request["operation_id"])
+        if saved:
+            if saved.get("project") != project or saved.get("request_sha256") != _hash(request):
+                raise ValueError("Copy operation belongs to another request or project.")
+            shutil.rmtree(os.path.join(directory, "stage"), ignore_errors=True)
+            return {"catalog": store.public_catalog(project, create=False), "receipt": saved, "replayed": True}
+        job = _read(path)
+        if job and job["request"] != request:
+            raise ValueError("Copy operation belongs to another request.")
+        if job and job["phase"] == "rejected":
+            raise native.ProjectAssetConflictError("This copy was rejected. Review a new copy request.")
+        try:
+            if not job or job["phase"] != "prepared":
+                preview, target, source = _snapshot(store, project, request["source_project"], request["asset_id"], request["enabled"], request["folder_id"])
+                if preview["base_revision"] != request["base_revision"] or preview["preview_revision"] != request["preview_revision"]:
+                    raise native.ProjectAssetConflictError("Source or destination changed after review.")
+                if not preview["copyable"]:
+                    raise ValueError(preview["issue"])
+                if not job:
+                    root = os.path.dirname(directory)
+                    if len(os.listdir(root)) > 1024:
+                        raise ValueError("The retained copy-operation limit was reached.")
+                native._atomic_json(path, {"request": request, "phase": "staging"})
+                job = _stage(store, directory, request, target, source, preview)
+                native._atomic_json(path, job)
+            _publish_files(store, project, directory, job)
+            _publish(store, project, request, job)
+        except (ValueError, TypeError) as exc:
+            # A rejected publication removes only this operation's unreferenced
+            # media. I/O failures retain their stage for exact retry instead.
+            current = store.load(project)
+            if request["operation_id"] not in (current.get("library_receipts") or {}):
+                for entry in (job or {}).get("assets", []):
+                    store._delete_asset_files(project, entry, current)
+                native._atomic_json(path, {"request": request, "phase": "rejected"})
+                shutil.rmtree(os.path.join(directory, "stage"), ignore_errors=True)
+            raise exc
+        shutil.rmtree(os.path.join(directory, "stage"), ignore_errors=True)
+        return {"catalog": store.public_catalog(project, create=False),
+                "receipt": store.load(project)["library_receipts"][request["operation_id"]], "replayed": False}

--- a/asset_copy.py
+++ b/asset_copy.py
@@ -87,15 +87,16 @@ def _read(path):
         return None
 
 
-def pending_copy(store, project, operation):
+def pending_operation(store, project, operation):
     job = _read(os.path.join(_directory(store, project, operation), "operation.json"))
     if not job or job["request"].get("project") != project or job["phase"] == "rejected":
         return None
-    return {"operation_id": operation, "action": "asset_copy", "phase": job["phase"],
+    return {"operation_id": operation, "action": job["request"]["action"], "phase": job["phase"],
+            "asset_id": job["request"]["asset_id"],
             "request": job["request"]}
 
 
-def pending_copies(store, project, catalog):
+def pending_operations(store, project, catalog):
     directory, _ = store._project_dir(project)
     root = os.path.join(directory, ".library_copies")
     if not os.path.isdir(root):
@@ -104,10 +105,19 @@ def pending_copies(store, project, catalog):
     for operation in sorted(os.listdir(root)):
         if not re.fullmatch(r"[0-9a-f]{32}", operation) or operation in (catalog.get("library_receipts") or {}):
             continue
-        item = pending_copy(store, project, operation)
+        item = pending_operation(store, project, operation)
         if item:
             result.append({key: value for key, value in item.items() if key != "request"})
     return result
+
+
+def pending_copy(store, project, operation):
+    value = pending_operation(store, project, operation)
+    return value if value and value["action"] == "asset_copy" else None
+
+
+def pending_copies(store, project, catalog):
+    return [item for item in pending_operations(store, project, catalog) if item["action"] == "asset_copy"]
 
 
 def finish_copy(store, project, receipt):
@@ -117,7 +127,7 @@ def finish_copy(store, project, receipt):
     in reverse order. After commit, retries follow the receipt path and no
     publisher can still need the staging bytes.
     """
-    if receipt.get("project") != project or receipt.get("action") != "asset_copy":
+    if receipt.get("project") != project or receipt.get("action") not in ("asset_copy", "asset_derive"):
         return
     directory = _directory(store, project, receipt["operation_id"])
     job = _read(os.path.join(directory, "operation.json"))
@@ -205,8 +215,8 @@ def _publish(store, project, request, job):
     if len(catalog.get("library_receipts") or {}) >= 1024:
         raise ValueError("The retained library-command limit was reached.")
     store._library_command = {"operation_id": request["operation_id"], "project": project,
-        "action": "asset_copy", "request_sha256": _hash(request), "before_revision": request["base_revision"],
-        "source_project": request["source_project"], "source_asset_id": request["asset_id"],
+        "action": request["action"], "request_sha256": _hash(request), "before_revision": request["base_revision"],
+        "source_project": request.get("source_project", project), "source_asset_id": request["asset_id"],
         "asset_ids_before": [item["id"] for item in catalog["assets"]],
         "folder_ids_before": [item["id"] for item in catalog["folders"]]}
     try:
@@ -217,12 +227,34 @@ def _publish(store, project, request, job):
 
 
 def command_copy(store, project, body):
+    def snapshot(store, project, request):
+        return _snapshot(store, project, request["source_project"], request["asset_id"], request["enabled"], request["folder_id"])
+    return command_staged(store, project, body, "asset_copy", FIELDS, snapshot, _stage)
+
+
+def command_staged(store, project, body, action, fields, snapshot, stage):
+    """Publish a native media operation's prepared assets with one receipt."""
     project = native._safe_project(project)
-    request = {key: body.get(key) for key in FIELDS}
-    if request["project"] != project or request["command_version"] != 1 or request["action"] != "asset_copy":
-        raise ValueError("Copy request does not match this project or command version.")
+    request = {key: body.get(key) for key in fields}
+    if request["project"] != project or request["command_version"] != 1 or request["action"] != action:
+        raise ValueError("Media request does not match this project or command version.")
     directory = _directory(store, project, request["operation_id"])
     path = os.path.join(directory, "operation.json")
+    saved = (store.load(project).get("library_receipts") or {}).get(request["operation_id"])
+    if saved:
+        if saved.get("project") != project or saved.get("request_sha256") != _hash(request):
+            raise ValueError("Media operation belongs to another request or project.")
+        finish_copy(store, project, saved)
+        return {"catalog": store.public_catalog(project, create=False), "receipt": saved, "replayed": True}
+    # Reserve a new operation before opening its lock file. Rejected new IDs
+    # must not create more directories after the retained-operation limit.
+    root = os.path.dirname(directory)
+    with native._catalog_lock(root), native._catalog_file_lock(root + ".admission"):
+        if not os.path.isdir(directory):
+            count = len([name for name in os.listdir(root) if re.fullmatch(r"[0-9a-f]{32}", name)]) if os.path.isdir(root) else 0
+            if count >= 1024:
+                raise ValueError("The retained media-operation limit was reached.")
+            os.makedirs(directory, exist_ok=True)
     # Operation lock first, then brief target commit lock. No source/target
     # pair of project locks is held while copying, including reciprocal imports.
     with native._catalog_lock(path), native._catalog_file_lock(path):
@@ -239,17 +271,13 @@ def command_copy(store, project, body):
             raise native.ProjectAssetConflictError("This copy was rejected. Review a new copy request.")
         try:
             if not job or job["phase"] != "prepared":
-                preview, target, source = _snapshot(store, project, request["source_project"], request["asset_id"], request["enabled"], request["folder_id"])
+                preview, target, source = snapshot(store, project, request)
                 if preview["base_revision"] != request["base_revision"] or preview["preview_revision"] != request["preview_revision"]:
                     raise native.ProjectAssetConflictError("Source or destination changed after review.")
                 if not preview["copyable"]:
                     raise ValueError(preview["issue"])
-                if not job:
-                    root = os.path.dirname(directory)
-                    if len(os.listdir(root)) > 1024:
-                        raise ValueError("The retained copy-operation limit was reached.")
                 native._atomic_json(path, {"request": request, "phase": "staging"})
-                job = _stage(store, directory, request, target, source, preview)
+                job = stage(store, directory, request, target, source, preview)
                 native._atomic_json(path, job)
             _publish_files(store, project, directory, job)
             _publish(store, project, request, job)

--- a/asset_copy.py
+++ b/asset_copy.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import shutil
+from contextlib import nullcontext
 
 if __package__:
     from . import project_assets as native
@@ -127,7 +128,7 @@ def finish_copy(store, project, receipt):
     in reverse order. After commit, retries follow the receipt path and no
     publisher can still need the staging bytes.
     """
-    if receipt.get("project") != project or receipt.get("action") not in ("asset_copy", "asset_derive"):
+    if receipt.get("project") != project or receipt.get("action") not in ("asset_copy", "asset_derive", "asset_capture"):
         return
     directory = _directory(store, project, receipt["operation_id"])
     job = _read(os.path.join(directory, "operation.json"))
@@ -226,13 +227,13 @@ def _publish(store, project, request, job):
         store._library_command = None
 
 
-def command_copy(store, project, body):
+def command_copy(store, project, body, *, commit_guard=nullcontext):
     def snapshot(store, project, request):
         return _snapshot(store, project, request["source_project"], request["asset_id"], request["enabled"], request["folder_id"])
-    return command_staged(store, project, body, "asset_copy", FIELDS, snapshot, _stage)
+    return command_staged(store, project, body, "asset_copy", FIELDS, snapshot, _stage, commit_guard=commit_guard)
 
 
-def command_staged(store, project, body, action, fields, snapshot, stage):
+def command_staged(store, project, body, action, fields, snapshot, stage, *, commit_guard=nullcontext):
     """Publish a native media operation's prepared assets with one receipt."""
     project = native._safe_project(project)
     request = {key: body.get(key) for key in fields}
@@ -279,8 +280,9 @@ def command_staged(store, project, body, action, fields, snapshot, stage):
                 native._atomic_json(path, {"request": request, "phase": "staging"})
                 job = stage(store, directory, request, target, source, preview)
                 native._atomic_json(path, job)
-            _publish_files(store, project, directory, job)
-            _publish(store, project, request, job)
+            with commit_guard():
+                _publish_files(store, project, directory, job)
+                _publish(store, project, request, job)
         except (ValueError, TypeError) as exc:
             # A rejected publication removes only this operation's unreferenced
             # media. I/O failures retain their stage for exact retry instead.

--- a/asset_image.py
+++ b/asset_image.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import copy
 import os
 import shutil
+from contextlib import nullcontext
 
 if __package__:
     from . import project_assets as native
@@ -108,5 +109,5 @@ def _stage(store, directory, request, catalog, parent, preview):
         "relative_path": entry["relative_path"], "sha256": entry["sha256"]}]}
 
 
-def command_image(store, project, body):
-    return command_staged(store, project, body, "asset_derive", FIELDS, _snapshot, _stage)
+def command_image(store, project, body, *, commit_guard=nullcontext):
+    return command_staged(store, project, body, "asset_derive", FIELDS, _snapshot, _stage, commit_guard=commit_guard)

--- a/asset_image.py
+++ b/asset_image.py
@@ -1,0 +1,112 @@
+"""Native image geometry and staged, conditional variant publication."""
+from __future__ import annotations
+
+import copy
+import os
+import shutil
+
+if __package__:
+    from . import project_assets as native
+    from .asset_copy import _hash, _stamp, command_staged
+else:
+    import project_assets as native
+    from asset_copy import _hash, _stamp, command_staged
+
+FIELDS = ("command_version", "project", "operation_id", "action", "base_revision",
+          "asset_id", "crop", "target", "resample", "tag", "folder_id", "preview_revision")
+RESAMPLING = ("lanczos", "bicubic", "bilinear", "nearest", "box", "hamming")
+
+
+def _source(store, project, asset_id):
+    entry, path = store.asset(project, asset_id)
+    if entry["kind"] != "image":
+        raise ValueError("Choose a picture asset to create an image variant.")
+    if native.Image is None or native.ImageOps is None:
+        raise ValueError("Pillow is required for image variants.")
+    with native.Image.open(path) as opened:
+        image = native.ImageOps.exif_transpose(opened)
+        width, height = image.size
+    return entry, path, width, height
+
+
+def inspect_image(store, project, asset_id, edit=None):
+    catalog = store.load(project)
+    entry, path, width, height = _source(store, project, asset_id)
+    value = {"project": catalog["project"], "asset_id": asset_id, "base_revision": _stamp(catalog),
+        "asset": entry, "source": {"width": width, "height": height},
+        "resampling": list(RESAMPLING), "max_pixels": native.MAX_DERIVED_IMAGE_PIXELS}
+    if edit is None:
+        return value
+    if not isinstance(edit, dict):
+        raise ValueError("Image edit must be a JSON object.")
+    crop, target = edit.get("crop"), edit.get("target")
+    for fields, keys in ((crop, ("x", "y", "width", "height")), (target, ("width", "height"))):
+        if not isinstance(fields, dict) or any(type(fields.get(key)) is not int for key in keys):
+            raise ValueError("Crop and target dimensions must be whole pixels.")
+    # Geometry validation uses the same oriented image bounds as native derive.
+    bounds = type("ImageBounds", (), {"width": width, "height": height})()
+    geometry = native._image_operation_geometry(bounds, crop, target)
+    resample, _ = native._image_resampling(edit.get("resample"))
+    folder = str(edit.get("folder_id") or "")
+    if folder and folder not in {item["id"] for item in catalog["folders"]}:
+        raise ValueError("The destination folder no longer exists.")
+    tag = native._safe_tag(edit.get("tag"), entry["tag"] + "_variant")
+    stat = os.stat(path)
+    value.update({"crop": dict(zip(("x", "y", "width", "height"), geometry[:4])),
+        "target": {"width": geometry[4], "height": geometry[5]}, "resample": resample,
+        "tag": tag, "folder_id": folder, "copyable": len(catalog["assets"]) < native.MAX_CATALOG_ASSETS,
+        "issue": "The asset catalog is full." if len(catalog["assets"]) >= native.MAX_CATALOG_ASSETS else ""})
+    value["preview_revision"] = _hash([value, entry.get("sha256"), stat.st_size, stat.st_mtime_ns])
+    return value
+
+
+def _snapshot(store, project, request):
+    preview = inspect_image(store, project, request["asset_id"], request)
+    catalog = store.load(project)
+    if _stamp(catalog) != preview["base_revision"]:
+        raise native.ProjectAssetConflictError("The library changed during image review.")
+    return preview, catalog, preview["asset"]
+
+
+def _stage(store, directory, request, catalog, parent, preview):
+    scratch = os.path.join(directory, "stage")
+    shutil.rmtree(scratch, ignore_errors=True)
+    project, asset_id = catalog["project"], request["asset_id"]
+    source_path = store._asset_path(project, parent)
+    source_digest = native._file_sha256(source_path)
+    if parent.get("sha256") and source_digest != parent["sha256"]:
+        raise native.ProjectAssetConflictError("The source image no longer matches its reviewed bytes.")
+    os.makedirs(scratch, exist_ok=True)
+    frozen_source = os.path.join(scratch, "source" + os.path.splitext(source_path)[1])
+    shutil.copy2(source_path, frozen_source)
+    if native._file_sha256(frozen_source) != source_digest:
+        raise native.ProjectAssetConflictError("The source image changed while staging its bytes.")
+
+    class StagedStore(native.ProjectAssetStore):
+        def asset(self, selected_project, selected_id):
+            if selected_project == project and selected_id == asset_id:
+                return copy.deepcopy(parent), frozen_source
+            return super().asset(selected_project, selected_id)
+
+    staged = StagedStore(os.path.join(scratch, "input"), os.path.join(scratch, "output"))
+    staged_dir, _ = staged._project_dir(project)
+    native._atomic_json(os.path.join(staged_dir, "catalog.json"), catalog)
+    result = staged.derive_image(project, asset_id, **{key: request[key] for key in
+        ("crop", "target", "resample", "tag", "folder_id", "operation_id")})
+    if result.get("reused"):
+        raise ValueError("This image operation ID already belongs to a native variant.")
+    entry = result["asset"]
+    relative = entry["relative_path"]
+    entry["relative_path"] = "images/%s_%s" % (request["operation_id"], os.path.basename(relative))
+    entry["input_path"] = "h3_projects/%s/%s" % (project, entry["relative_path"])
+    if parent.get("source_origin"):
+        entry["source_origin"] = copy.deepcopy(parent["source_origin"])
+    if native._file_sha256(source_path) != source_digest or inspect_image(store, project, asset_id, request)["preview_revision"] != request["preview_revision"]:
+        raise native.ProjectAssetConflictError("Source image or library changed while deriving the variant.")
+    return {"request": request, "phase": "prepared", "assets": [entry], "files": [{
+        "staged": os.path.relpath(os.path.join(staged_dir, relative), directory),
+        "relative_path": entry["relative_path"], "sha256": entry["sha256"]}]}
+
+
+def command_image(store, project, body):
+    return command_staged(store, project, body, "asset_derive", FIELDS, _snapshot, _stage)

--- a/asset_library.py
+++ b/asset_library.py
@@ -7,10 +7,12 @@ import re
 
 if __package__:
     from .project_assets import ProjectAssetConflictError, _project_mutation
-    from .asset_copy import command_copy, pending_copy, finish_copy
+    from .asset_copy import command_copy, pending_copy, pending_operation, finish_copy
+    from .asset_image import command_image
 else:
     from project_assets import ProjectAssetConflictError, _project_mutation
-    from asset_copy import command_copy, pending_copy, finish_copy
+    from asset_copy import command_copy, pending_copy, pending_operation, finish_copy
+    from asset_image import command_image
 
 MAX_COMMANDS = 1024
 ACTIONS = frozenset(("folder_create", "folder_update", "folder_delete",
@@ -36,12 +38,15 @@ def inspect_library(store, project, operation_id=""):
         finish_copy(store, project, receipt)
     return {"catalog": store.public_catalog(project, create=False),
             "receipt": _receipt(receipt) if receipt else None,
-            "pending_copy": pending_copy(store, project, operation_id) if operation_id and not receipt else None}
+            "pending_copy": pending_copy(store, project, operation_id) if operation_id and not receipt else None,
+            "pending_operation": pending_operation(store, project, operation_id) if operation_id and not receipt else None}
 
 
 def command_library(store, project, body):
     if isinstance(body, dict) and body.get("action") == "asset_copy":
         return command_copy(store, project, body)
+    if isinstance(body, dict) and body.get("action") == "asset_derive":
+        return command_image(store, project, body)
     return _command_library(store, project, body)
 
 

--- a/asset_library.py
+++ b/asset_library.py
@@ -1,0 +1,102 @@
+"""Conditional library editing over the native ProjectAssetStore operations."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+if __package__:
+    from .project_assets import ProjectAssetConflictError, _project_mutation
+else:
+    from project_assets import ProjectAssetConflictError, _project_mutation
+
+MAX_COMMANDS = 1024
+ACTIONS = frozenset(("folder_create", "folder_update", "folder_delete",
+    "folder_reorder", "asset_update", "asset_duplicate", "asset_delete", "asset_reorder"))
+
+
+def _receipt(value):
+    return {key: item for key, item in value.items()
+            if key not in ("cleanup_asset", "asset_ids_before", "folder_ids_before")}
+
+
+@_project_mutation
+def inspect_library(store, project, operation_id=""):
+    catalog = store.load(project)
+    receipt = (catalog.get("library_receipts") or {}).get(str(operation_id))
+    if receipt and receipt.get("project") != catalog["project"]:
+        receipt = None
+    if receipt and receipt.get("cleanup_asset"):
+        # Finish cleanup for the already committed deletion before confirming
+        # it. Current catalog references still protect any reused media.
+        store._delete_asset_files(project, receipt["cleanup_asset"], catalog)
+    return {"catalog": store.public_catalog(project, create=False),
+            "receipt": _receipt(receipt) if receipt else None}
+
+
+@_project_mutation
+def command_library(store, project, body):
+    if not isinstance(body, dict) or body.get("command_version") != 1:
+        raise ValueError("Unsupported asset library command version.")
+    action = body.get("action")
+    if action not in ACTIONS:
+        raise ValueError("Unsupported asset library action.")
+    operation = str(body.get("operation_id") or "")
+    if not re.fullmatch(r"[0-9a-f]{32}", operation):
+        raise ValueError("A 32-character library operation ID is required.")
+    expected = body.get("base_revision")
+    if expected != "empty" and not re.fullmatch(r"[0-9a-f]{32}", str(expected or "")):
+        raise ValueError("Review the current library before changing it.")
+    request = {key: body.get(key) for key in ("action", "base_revision", "asset_id",
+        "folder_id", "name", "color", "tag", "changes", "asset_ids", "folder_ids")}
+    fingerprint = hashlib.sha256(json.dumps(request, sort_keys=True,
+        ensure_ascii=False, separators=(",", ":")).encode()).hexdigest()
+    catalog = store.load(project)
+    saved = (catalog.get("library_receipts") or {}).get(operation)
+    if saved:
+        if saved["project"] != catalog["project"] or saved["request_sha256"] != fingerprint:
+            raise ValueError("Library operation ID already belongs to another request or project.")
+        if saved.get("cleanup_asset"):
+            store._delete_asset_files(project, saved["cleanup_asset"], catalog)
+        return {**inspect_library(store, project, operation), "replayed": True}
+    if str(catalog.get("storage_revision") or "empty") != expected:
+        raise ProjectAssetConflictError("The library changed. Refresh and review before applying.")
+    if len(catalog.get("library_receipts") or {}) >= MAX_COMMANDS:
+        raise ValueError("The project reached its retained library-command limit; no receipts were discarded.")
+    if action == "asset_update":
+        changes = body.get("changes")
+        if not isinstance(changes, dict) or not changes or set(changes) - {"tag", "role", "enabled", "lyrics", "folder_id", "options"}:
+            raise ValueError("Unsupported asset fields.")
+    if action == "folder_update":
+        changes = body.get("changes")
+        if not isinstance(changes, dict) or not changes or set(changes) - {"name", "color"}:
+            raise ValueError("Unsupported folder fields.")
+    pending = {"operation_id": operation, "project": catalog["project"],
+        "action": action, "request_sha256": fingerprint, "before_revision": expected,
+        "asset_ids_before": [item["id"] for item in catalog["assets"]],
+        "folder_ids_before": [item["id"] for item in catalog["folders"]]}
+    if action == "asset_delete":
+        pending["cleanup_asset"] = next(({key: item.get(key) for key in ("id", "relative_path")} for item in catalog["assets"]
+            if item["id"] == body.get("asset_id")), None)
+    store._library_command = pending
+    try:
+        if action == "folder_create":
+            store.create_folder(project, body.get("name"), color=body.get("color", ""))
+        elif action == "folder_update":
+            store.update_folder(project, body.get("folder_id"), body["changes"])
+        elif action == "folder_delete":
+            store.delete_folder(project, body.get("folder_id"))
+        elif action == "folder_reorder":
+            store.reorder_folders(project, body.get("folder_ids"))
+        elif action == "asset_reorder":
+            store.reorder(project, body.get("asset_ids"))
+        elif action == "asset_update":
+            store.update(project, body.get("asset_id"), body["changes"])
+        elif action == "asset_duplicate":
+            store.duplicate(project, body.get("asset_id"), tag=body.get("tag", ""),
+                            folder_id=body.get("folder_id") if "folder_id" in body else None)
+        else:
+            store.delete(project, body.get("asset_id"))
+    finally:
+        store._library_command = None
+    return {**inspect_library(store, project, operation), "replayed": False}

--- a/asset_library.py
+++ b/asset_library.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from contextlib import nullcontext
 
 if __package__:
     from .project_assets import ProjectAssetConflictError, _project_mutation
@@ -42,11 +43,11 @@ def inspect_library(store, project, operation_id=""):
             "pending_operation": pending_operation(store, project, operation_id) if operation_id and not receipt else None}
 
 
-def command_library(store, project, body):
+def command_library(store, project, body, *, commit_guard=nullcontext):
     if isinstance(body, dict) and body.get("action") == "asset_copy":
-        return command_copy(store, project, body)
+        return command_copy(store, project, body, commit_guard=commit_guard)
     if isinstance(body, dict) and body.get("action") == "asset_derive":
-        return command_image(store, project, body)
+        return command_image(store, project, body, commit_guard=commit_guard)
     return _command_library(store, project, body)
 
 

--- a/asset_library.py
+++ b/asset_library.py
@@ -7,8 +7,10 @@ import re
 
 if __package__:
     from .project_assets import ProjectAssetConflictError, _project_mutation
+    from .asset_copy import command_copy, pending_copy, finish_copy
 else:
     from project_assets import ProjectAssetConflictError, _project_mutation
+    from asset_copy import command_copy, pending_copy, finish_copy
 
 MAX_COMMANDS = 1024
 ACTIONS = frozenset(("folder_create", "folder_update", "folder_delete",
@@ -30,12 +32,21 @@ def inspect_library(store, project, operation_id=""):
         # Finish cleanup for the already committed deletion before confirming
         # it. Current catalog references still protect any reused media.
         store._delete_asset_files(project, receipt["cleanup_asset"], catalog)
+    if receipt:
+        finish_copy(store, project, receipt)
     return {"catalog": store.public_catalog(project, create=False),
-            "receipt": _receipt(receipt) if receipt else None}
+            "receipt": _receipt(receipt) if receipt else None,
+            "pending_copy": pending_copy(store, project, operation_id) if operation_id and not receipt else None}
+
+
+def command_library(store, project, body):
+    if isinstance(body, dict) and body.get("action") == "asset_copy":
+        return command_copy(store, project, body)
+    return _command_library(store, project, body)
 
 
 @_project_mutation
-def command_library(store, project, body):
+def _command_library(store, project, body):
     if not isinstance(body, dict) or body.get("command_version") != 1:
         raise ValueError("Unsupported asset library command version.")
     action = body.get("action")

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -110,6 +110,7 @@ from .review_inventory import (
 )
 from .prompt_history import PromptHistoryStore
 from .asset_library import command_library, inspect_library
+from .asset_copy import preview_copy
 from .prompt_optimizer import optimize_prompt_payload
 from .run_manager import RunArchiveManager, archive_policy_inputs
 from .asset_store import MAX_DIRECT_ASSET_BINDINGS, RunAssetStore
@@ -30991,6 +30992,14 @@ def _project_asset_error_response(exc: Exception):
 async def _project_asset_catalog(request):
     try:
         project = request.query.get("project", "")
+        if request.query.get("copy_source"):
+            enabled = request.query.get("enabled", "true")
+            if enabled not in ("true", "false"):
+                raise ValueError("Copy enabled must be true or false.")
+            result = await asyncio.to_thread(preview_copy, _project_asset_store(), project,
+                request.query["copy_source"], request.query.get("copy_asset", ""),
+                enabled == "true", request.query.get("folder_id", ""))
+            return web.json_response(result)
         if request.query.get("operation_id"):
             result = await asyncio.to_thread(inspect_library, _project_asset_store(),
                 project, request.query["operation_id"])

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -111,6 +111,7 @@ from .review_inventory import (
 from .prompt_history import PromptHistoryStore
 from .asset_library import command_library, inspect_library
 from .asset_copy import preview_copy
+from .asset_image import inspect_image
 from .prompt_optimizer import optimize_prompt_payload
 from .run_manager import RunArchiveManager, archive_policy_inputs
 from .asset_store import MAX_DIRECT_ASSET_BINDINGS, RunAssetStore
@@ -30992,6 +30993,11 @@ def _project_asset_error_response(exc: Exception):
 async def _project_asset_catalog(request):
     try:
         project = request.query.get("project", "")
+        if request.query.get("image_asset"):
+            edit = json.loads(request.query["image_edit"]) if "image_edit" in request.query else None
+            result = await asyncio.to_thread(inspect_image, _project_asset_store(), project,
+                request.query["image_asset"], edit)
+            return web.json_response(result)
         if request.query.get("copy_source"):
             enabled = request.query.get("enabled", "true")
             if enabled not in ("true", "false"):

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -109,6 +109,7 @@ from .review_inventory import (
     write_review_snapshot as _write_review_snapshot,
 )
 from .prompt_history import PromptHistoryStore
+from .asset_library import command_library, inspect_library
 from .prompt_optimizer import optimize_prompt_payload
 from .run_manager import RunArchiveManager, archive_policy_inputs
 from .asset_store import MAX_DIRECT_ASSET_BINDINGS, RunAssetStore
@@ -30990,11 +30991,36 @@ def _project_asset_error_response(exc: Exception):
 async def _project_asset_catalog(request):
     try:
         project = request.query.get("project", "")
+        if request.query.get("operation_id"):
+            result = await asyncio.to_thread(inspect_library, _project_asset_store(),
+                project, request.query["operation_id"])
+            return web.json_response(result)
         catalog = await asyncio.to_thread(
             _project_asset_store().public_catalog, project,
             create=request.query.get("create", "true").lower() != "false")
         return web.json_response(catalog)
     except (OSError, TypeError, ValueError) as exc:
+        return _project_asset_error_response(exc)
+
+
+async def _project_asset_library(request):
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise ValueError("Asset library command must be a JSON object.")
+        project = body.get("project", "")
+        rejection = _project_write_rejection(request, project, "edit the project library")
+        if rejection is not None:
+            return rejection
+        result = await asyncio.to_thread(_owned_project_mutation,
+            project, _request_project_ownership(request), "edit the project library",
+            command_library, _project_asset_store(), project, body)
+        return web.json_response(result)
+    except OSError as exc:
+        # The catalog/receipt may already be durable. Retain the request and
+        # reconcile its operation instead of treating I/O as a rejected write.
+        return web.json_response({"error": str(exc)}, status=500)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
         return _project_asset_error_response(exc)
 
 
@@ -31903,6 +31929,8 @@ if (PromptServer is not None and web is not None and
     PromptServer.instance.routes.get(
         "/minimax_h3_context_loop/project-assets/sources")(
             _project_asset_sources)
+    PromptServer.instance.routes.post(
+        "/minimax_h3_context_loop/project-assets/library")(_project_asset_library)
     PromptServer.instance.routes.post(
         "/minimax_h3_context_loop/project-assets/upload")(
             _project_asset_upload)

--- a/chain_nodes.py
+++ b/chain_nodes.py
@@ -112,6 +112,7 @@ from .prompt_history import PromptHistoryStore
 from .asset_library import command_library, inspect_library
 from .asset_copy import preview_copy
 from .asset_image import inspect_image
+from .asset_capture import inspect_capture, command_capture
 from .prompt_optimizer import optimize_prompt_payload
 from .run_manager import RunArchiveManager, archive_policy_inputs
 from .asset_store import MAX_DIRECT_ASSET_BINDINGS, RunAssetStore
@@ -30993,6 +30994,10 @@ def _project_asset_error_response(exc: Exception):
 async def _project_asset_catalog(request):
     try:
         project = request.query.get("project", "")
+        if request.query.get("capture_frame"):
+            result = await asyncio.to_thread(inspect_capture, _project_asset_store(), project,
+                json.loads(request.query["capture_frame"]), _saved_capture_source)
+            return web.json_response(result)
         if request.query.get("image_asset"):
             edit = json.loads(request.query["image_edit"]) if "image_edit" in request.query else None
             result = await asyncio.to_thread(inspect_image, _project_asset_store(), project,
@@ -31027,6 +31032,17 @@ async def _project_asset_library(request):
         rejection = _project_write_rejection(request, project, "edit the project library")
         if rejection is not None:
             return rejection
+        if body.get("action") == "asset_capture":
+            proof = _request_project_ownership(request)
+            result = await asyncio.to_thread(command_capture, _project_asset_store(), project, body,
+                _saved_capture_source, _capture_video_frame,
+                lambda: _project_write_commit_guard(project, proof, "publish a captured frame"))
+            return web.json_response(result)
+        if body.get("action") in ("asset_copy", "asset_derive"):
+            proof = _request_project_ownership(request)
+            result = await asyncio.to_thread(command_library, _project_asset_store(), project, body,
+                commit_guard=lambda: _project_write_commit_guard(project, proof, "publish project media"))
+            return web.json_response(result)
         result = await asyncio.to_thread(_owned_project_mutation,
             project, _request_project_ownership(request), "edit the project library",
             command_library, _project_asset_store(), project, body)
@@ -31035,7 +31051,7 @@ async def _project_asset_library(request):
         # The catalog/receipt may already be durable. Retain the request and
         # reconcile its operation instead of treating I/O as a rejected write.
         return web.json_response({"error": str(exc)}, status=500)
-    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+    except (RuntimeError, TypeError, ValueError, json.JSONDecodeError) as exc:
         return _project_asset_error_response(exc)
 
 
@@ -31460,6 +31476,41 @@ async def _project_ownership_command(request):
         }, status=423)
     except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
         return web.json_response({"error": str(exc)}, status=400)
+
+
+def _saved_capture_source(project: Any, request: Any) -> dict[str, Any]:
+    """Resolve only the exact saved take/media identity displayed by the viewer."""
+    project = _strict_run_name(project)
+    if not isinstance(request, dict) or not isinstance(request.get("source"), dict):
+        raise ValueError("Choose a saved clip frame to capture.")
+    source = request["source"]
+    if set(source) != {"scene", "revision", "branch_id", "file"} or type(source["scene"]) is not int:
+        raise ValueError("A saved scene, revision, branch and media file are required.")
+    media = source["file"]
+    if not isinstance(media, dict) or set(media) != {"filename", "subfolder", "type"} or media.get("type") != "output":
+        raise ValueError("Frame capture requires the saved output video identity.")
+    if not all(isinstance(value, str) for value in media.values()):
+        raise ValueError("Saved video paths must be strings.")
+    path = _capture_frame_video_path(media["filename"], media["subfolder"], media["type"])
+    metadata, metadata_path = _load_checkpoint_revision(project, source["scene"], source["revision"], verify_artifacts=False)
+    segment = metadata["segment"]
+    raw = os.path.realpath(_absolute_output_path(segment["segment"]))
+    if path != raw:
+        with branch_scope(project, source["branch_id"]):
+            review_dir = os.path.realpath(os.path.join(_run_dir({"run_name": project}), "reviews"))
+        preview = _checkpoint_review_preview(source["scene"], segment, review_dir, [media["filename"]])
+        if preview is None or os.path.realpath(preview) != path:
+            raise ValueError("Displayed media does not belong to the selected saved revision.")
+    # Validate branch even when the selected source is the immutable raw clip.
+    _working_branch_id(source["branch_id"])
+    offset = _capture_frame_time(request.get("time_seconds"))
+    if offset >= int(segment.get("delivered_frames") or 0) / FPS:
+        raise ValueError("Frame time must be inside the saved clip's delivered duration.")
+    digest = _file_sha256(path)
+    if path == raw and segment.get("segment_sha256") and digest != segment["segment_sha256"]:
+        raise ProjectAssetConflictError("The saved video no longer matches its checkpoint bytes.")
+    return {"path": path, "time_seconds": offset, "sha256": digest,
+        "metadata_sha256": _file_sha256(metadata_path)}
 
 
 def _capture_frame_video_path(filename: Any, subfolder: Any, kind: Any) -> str:

--- a/docs/asset-capture-commands.md
+++ b/docs/asset-capture-commands.md
@@ -1,0 +1,67 @@
+# Reviewed saved-frame captures
+
+Catalogs advertise `library_capture_version: 1`. This command saves one picture
+from an existing H3 scene revision. It uses native FFmpeg frame extraction and
+native picture import/tag-numbering rules. It never queues a workflow or model.
+
+Read `GET /minimax_h3_context_loop/project-assets?project=<run>&create=false&capture_frame=<JSON>`.
+The URL-encoded selection contains:
+
+```json
+{
+  "source": {
+    "scene": 2,
+    "revision": "0123456789abcdef0123456789abcdef",
+    "branch_id": "main",
+    "file": {"filename": "clip.webm", "subfolder": "h3_chains/film/segments", "type": "output"}
+  },
+  "time_seconds": 1.25,
+  "tag": "arrival_capture",
+  "folder_id": ""
+}
+```
+
+Use the displayed video's local `currentTime`, not its sequence placement or
+the Plan selection cursor. Supply the displayed picture revision: an ALT uses
+its own revision and video even when audio comes from the base take. The viewer
+must reject seeking, unloaded or failed media, gaps, and unsaved sources.
+
+Review verifies immutable checkpoint metadata, exact raw-video or native review
+preview membership, branch, output confinement, media and metadata SHA-256,
+finite in-duration time, destination folder and catalog capacity. It returns
+`base_revision`, `preview_revision`, normalized tag and eligibility. No catalog
+or preview asset is created. Reading hashes can take time for large files.
+
+POST the selection and both reviewed revisions to the existing `/project-assets/library`
+route with `action: "asset_capture"`, `command_version: 1`, `project`, and a new
+32-hex `operation_id`. The source is a saved clip; `asset_id` is not required.
+The caller supplies the normal native ownership headers. The original
+`/project-assets/capture-frame` endpoint remains compatible with native clients.
+
+The operation checks source identity before and after native extraction, then
+imports into a private store. Native numbered tags and destination folder are
+retained. The enabled picture, `source_origin` (project, scene, revision, branch,
+media identity, clip time and hashes), transform/operation ID and receipt are
+published in one authoritative catalog commit. Captions/monitor overlays are
+not baked into the picture. The source clip, checkpoint, cut and Plan are unchanged.
+
+All reviewed staged media commands use the same lock order: operation lock,
+then a short ownership guard, then catalog commit. Ownership is checked at
+admission and again around media promotion/publication. Extraction and copy
+preparation do not hold the ownership lock; a takeover can proceed and fences
+publication. Different actions cannot invert these locks on a reused operation
+ID. Source/catalog changes reject publication and remove only this operation's
+unreferenced media. Extraction failure is a rejected operation.
+
+Prepared images and exact requests survive restart in the shared bounded
+staging mechanism. `library_pending_operations` and the operation-status read
+expose `asset_capture`; a prepared capture can publish after source removal
+without extracting again. A changed destination still requires a new review.
+An I/O failure returns 500 because its catalog/receipt may already have committed.
+Check that exact operation before retrying; receipt replay never creates another
+picture. Existing copy/variant limits and primary/mirror guarantees apply.
+
+`tests/_asset_capture_commands_test.py` uses real temporary two-color videos and
+CPU stubs to check requested-time pixels, saved/review identities, provenance,
+numbered tags, source/metadata/catalog changes, ownership takeover, single commit,
+interruption/restart, lost acknowledgement, exact replay and real route admission.

--- a/docs/asset-image-commands.md
+++ b/docs/asset-image-commands.md
@@ -1,0 +1,60 @@
+# Reviewed image variants
+
+Public project catalogs advertise `library_image_version: 1`. Read the oriented
+source geometry using `GET /minimax_h3_context_loop/project-assets?project=<run>&create=false&image_asset=<id>`.
+The response includes exact project/asset identity, the native storage revision,
+oriented source dimensions, supported resampling modes and the maximum output
+pixel count. It does not create or alter a catalog. Non-picture and unavailable
+sources are rejected.
+
+Add URL-encoded `image_edit=<JSON>` to review a variant. Its fields are:
+
+- `crop`: whole-pixel `x`, `y`, `width`, `height` in the EXIF-oriented source.
+- `target`: whole-pixel `width`, `height`.
+- `resample`: a supported native filter.
+- `tag`: requested variant tag; native registration chooses a unique tag.
+- `folder_id`: an existing destination folder, or an empty string for unfiled.
+
+Review uses the same geometry and resampling validation as
+`ProjectAssetStore.derive_image`. It returns normalized geometry/tag/filter,
+`base_revision`, `preview_revision`, and catalog-capacity eligibility. The
+review fingerprint covers the source entry, catalog storage stamp, media
+identity and edit intent. A caller must retain its reviewed fields.
+
+Submit those fields to `POST /minimax_h3_context_loop/project-assets/library`
+with `action: "asset_derive"`, `command_version: 1`, the project/asset identities,
+a new 32-hex `operation_id`, and both reviewed revisions. Native target ownership
+is mandatory. Fractional/invalid coordinates, out-of-bounds crops, oversized
+targets, missing folders and unsupported filters fail before publication.
+
+The command freezes and hash-checks source bytes, then invokes the existing
+native `derive_image` and `register_derived_image` methods in a private staging
+store. The native crop, EXIF orientation, transparency, resize, role, options,
+tag and transform rules remain authoritative. Source provenance is retained;
+the new enabled image keeps its local `parent_asset_id` and native `transform`.
+The source catalog entry, original bytes and workflow Plan are not edited.
+
+The shared staged-media mechanism promotes verified output media and publishes
+the complete variant plus its receipt in one authoritative catalog commit.
+It inherits the copy command's file protection, storage CAS, ownership,
+interruption, exact-replay and primary/mirror boundaries. A retained prepared
+variant can finish from frozen bytes after restart; a changed destination
+requires a fresh review. No upscale model or GPU queue is used.
+
+`library_pending_operations` lists staged copies and image variants, including
+their action, root asset ID, operation ID and persisted phase.
+`library_pending_copies` remains limited to cross-project copies for older
+clients. Operation-status reads include `pending_operation` with the exact
+saved request; `pending_copy` remains a compatibility field for copies only.
+A reopened companion can explicitly resume the original media request with
+current project ownership. A phase is not proof that a worker is running.
+Committed status reads also clean leftover private staging on a best-effort
+basis. Admission is serialized and rejects before allocating a new directory
+at 1,024 retained media operations. Existing receipts remain replayable.
+
+`tests/_asset_image_test.py` verifies actual selected pixels, alpha, oriented
+geometry, native provenance, one catalog commit, unchanged originals, invalid
+and stale reviews, interruption/restart/replay and the admission limit.
+`tests/_asset_library_api_test.py` exercises real image-inspect/save/replay routes
+and real ownership rejection with temporary CPU-only fixtures. Existing copy,
+library and native-store checks remain applicable.

--- a/docs/asset-library-commands.md
+++ b/docs/asset-library-commands.md
@@ -39,15 +39,16 @@ not select a separate library. Send a JSON object with `project`,
 | `asset_reorder` | `asset_ids`, an exact permutation of every asset |
 | `asset_duplicate` | `asset_id`, optional `tag` and `folder_id` |
 | `asset_delete` | `asset_id` |
+| `asset_copy` | `source_project`, `asset_id`, boolean `enabled`, `folder_id` (empty for unfiled), `preview_revision`; requires `library_copy_version: 1` |
 
 The native store preserves shared media when duplicating cards, disables a
 duplicated Source track, and retains its existing tag, role, track-group and
 folder validation. Deleting a folder preserves its media. Deleting an asset
 protects track-group members and media paths still shared by another card.
 This API does not add cross-Plan/branch usage analysis or rewrite prompt tags.
-Cross-project copying, upload, derived-image jobs and whole-project duplication
-retain their existing endpoints; their multi-step operations are not covered
-by this single-catalog command transaction.
+Upload, derived-image jobs, whole-project duplication and the legacy import
+endpoint retain their existing behavior. Reviewed cross-project copies use the
+new command described below.
 
 On success the response is `{catalog, receipt, replayed}`. Repeat only the exact
 request/operation ID after an uncertain result. A matching retained receipt is
@@ -91,3 +92,56 @@ stubs and the real ownership guard, covering 409/423/500 and receipt reads.
 Existing store, editor and catalog-notification tests remain applicable.
 All projects and images are temporary fixtures; no production GPU workflow is
 executed by this validation.
+
+## Reviewed copies from another project
+
+Public catalogs advertise `library_copy_version: 1` and
+`library_pending_copies: [{operation_id, action, phase}]`. Browse source project
+summaries through the existing `/project-assets/projects` endpoint and read a
+chosen catalog with `project=<source>&create=false`. Original previews use the
+existing source-project `/project-assets/media` endpoint.
+
+Review with `GET /project-assets?project=<destination>&copy_source=<source>&copy_asset=<id>&enabled=true|false&folder_id=<folder>`.
+The response identifies both projects and the root asset, destination
+`base_revision`, source storage revision, all required audio dependencies,
+`copyable`, an explanatory `issue`, and a 64-hex `preview_revision`. The review
+covers the catalogs, selected folder/enabled intent and source media identities.
+Missing media, malformed track bindings and catalog capacity prevent a copy.
+Only one enabled Source track is allowed; choosing a disabled copy preserves an
+existing soundtrack. Reading/reviewing does not request a project write.
+
+Submit `asset_copy` through `/library` with the exact review fields. The native
+importer runs in a private project store beneath `.library_copies/<operation>`.
+Its normal multi-save group import never publishes partial destination state.
+Root/stem IDs and audio links are remapped, dependency stems are disabled audio
+references, tags remain unique, lyrics/options survive and the chosen folder
+contains the entire copied group. `source_origin` records source project/asset,
+source parent, transform and prior provenance without leaving a dangling local
+parent or reusing a source transform operation ID.
+
+Source hashes and catalog/media identities are checked before preparation is
+accepted. The prepared manifest freezes the copied bytes and final new asset
+IDs. Retry can therefore finish those same bytes even if the source later
+changes. Operation locks serialize exact retries across processes, while the
+brief target catalog commit still uses native storage CAS. Reciprocal imports
+never hold both project locks. New media uses operation-specific paths in input
+and output stores; only after both copies exist does one authoritative catalog
+commit publish the entire group and its receipt. Rejected publication cleans
+this operation's unreferenced media. I/O interruption keeps the stage for retry;
+an interrupted process can leave staged/promoted files until recovery.
+
+An operation-status read without a receipt returns `pending_copy`, including
+the saved request and phase. A reopened companion can offer **Resume saved
+import**, recover that exact request and submit it with current target ownership.
+A phase describes persisted progress, not proof that a process is still running.
+Never replace saved fields with current UI choices. A status read with a committed
+receipt can also finish private-stage cleanup. Finished/rejected stages are
+removed on a best-effort basis; small operation manifests remain to prevent ID
+reuse. At 1,024 retained copy operations, new imports stop without evicting IDs.
+Whole-project duplication and global dependency/usage analysis are separate.
+
+`tests/_asset_copy_test.py` checks grouped audio, derived provenance, a single
+authoritative publication, source immutability, missing/damaged media, Source
+track conflicts, stale catalogs, preparation/promotion/commit interruption,
+restart/retry and concurrent destination changes. The real route tests also
+exercise copy preview, replay and ownership rejection.

--- a/docs/asset-library-commands.md
+++ b/docs/asset-library-commands.md
@@ -1,0 +1,93 @@
+# Conditional asset-library editing
+
+Companion library views can remain open while the native Carousel changes a
+folder or asset. The command interface binds an edit to the reviewed storage
+revision and retains an operation receipt in the authoritative input-side
+catalog. It delegates all asset/folder semantics to `ProjectAssetStore`.
+
+## Read
+
+`GET /minimax_h3_context_loop/project-assets?project=<run>&create=false` retains
+the public catalog format and adds `library_command_version: 1` and
+`library_revision`. The revision is the native `storage_revision`, or `empty`
+for an absent catalog. It covers presentation-only changes such as folder names
+and colors; the generation fingerprint (`revision`) does not cover those.
+Reading an absent catalog with `create=false` does not create a project.
+Existing primary-from-mirror recovery behavior remains unchanged.
+
+Add `operation_id=<32 hex ID>` to read `{catalog, receipt}` for a retained command.
+An absent receipt is `null`. Catalog reads and command responses omit internal
+receipt storage. Public receipts include the project, action, request hash,
+before/after revision and created asset/folder IDs. They do not contain credentials,
+the full request, deleted lyrics/metadata, or internal cleanup paths.
+
+## Write
+
+`POST /minimax_h3_context_loop/project-assets/library` requires the existing
+native project ownership proof. Assets remain project-shared; `branch_id` does
+not select a separate library. Send a JSON object with `project`,
+`command_version: 1`, a new lowercase 32-hex `operation_id`, the reviewed
+`base_revision`, and one of these `action` values:
+
+| Action | Additional fields |
+| --- | --- |
+| `folder_create` | `name`, optional `color` |
+| `folder_update` | `folder_id`, `changes` containing `name` and/or `color` |
+| `folder_delete` | `folder_id`; native behavior unfiles its cards |
+| `folder_reorder` | `folder_ids`, an exact permutation of every folder |
+| `asset_update` | `asset_id`, `changes`: tag, role, enabled, lyrics, folder_id and/or options |
+| `asset_reorder` | `asset_ids`, an exact permutation of every asset |
+| `asset_duplicate` | `asset_id`, optional `tag` and `folder_id` |
+| `asset_delete` | `asset_id` |
+
+The native store preserves shared media when duplicating cards, disables a
+duplicated Source track, and retains its existing tag, role, track-group and
+folder validation. Deleting a folder preserves its media. Deleting an asset
+protects track-group members and media paths still shared by another card.
+This API does not add cross-Plan/branch usage analysis or rewrite prompt tags.
+Cross-project copying, upload, derived-image jobs and whole-project duplication
+retain their existing endpoints; their multi-step operations are not covered
+by this single-catalog command transaction.
+
+On success the response is `{catalog, receipt, replayed}`. Repeat only the exact
+request/operation ID after an uncertain result. A matching retained receipt is
+checked before the old base revision and cannot create another duplicate.
+Reusing an ID for different fields or a different project is rejected.
+
+HTTP 409 means the library changed, 423 means ownership rejected the write, and
+400 means invalid input. I/O errors use 500 because the catalog may already be
+committed. Keep the exact operation/body after transport, unreadable response or
+500 failures; query its receipt or retry it. A companion must not invent a fresh
+operation ID merely because the first acknowledgement was lost.
+
+## Persistence boundaries
+
+The native per-project process lock surrounds review validation and mutation.
+The reviewed revision is checked again when the operation's native method saves,
+so reloading newer state inside that method cannot silently bypass the review.
+Existing cross-process catalog CAS/file locking remains in use. Receipts are
+committed with the input-side catalog and retained by subsequent legacy writes.
+Public snapshots cannot erase them. The recovery mirror retains the existing
+best-effort publication behavior; input-side catalog commit is authoritative.
+
+Asset deletion commits catalog removal and its receipt before file cleanup.
+Operation-status reads and exact retries finish cleanup for that already
+authorized deletion, checking current catalog references before removing media.
+An asset restored with the same ID is left intact. Thus a status read can finish
+an earlier deletion; an ordinary library read never requests a new deletion.
+Cleanup is not a transaction across multiple ComfyUI processes or external file
+edits. Receipts survive restart but a caller still needs its original ID/body to
+retry. At 1,024 retained commands per project, new conditional commands stop
+instead of silently evicting IDs. Existing receipts stay readable/replayable.
+
+## Validation
+
+`tests/_asset_library_commands_test.py` checks empty reads and first creation,
+folder-only stale reviews, membership/order, native duplicate provenance, shared
+media deletion protection, interrupted responses and cleanup, restart/retry,
+legacy receipt retention and a native reload between review and commit.
+`tests/_asset_library_api_test.py` uses the real handlers with CPU-only ComfyUI
+stubs and the real ownership guard, covering 409/423/500 and receipt reads.
+Existing store, editor and catalog-notification tests remain applicable.
+All projects and images are temporary fixtures; no production GPU workflow is
+executed by this validation.

--- a/docs/asset-library-commands.md
+++ b/docs/asset-library-commands.md
@@ -40,15 +40,16 @@ not select a separate library. Send a JSON object with `project`,
 | `asset_duplicate` | `asset_id`, optional `tag` and `folder_id` |
 | `asset_delete` | `asset_id` |
 | `asset_copy` | `source_project`, `asset_id`, boolean `enabled`, `folder_id` (empty for unfiled), `preview_revision`; requires `library_copy_version: 1` |
+| `asset_derive` | `asset_id`, `crop`, `target`, `resample`, `tag`, `folder_id`, `preview_revision`; requires `library_image_version: 1`, see [image commands](asset-image-commands.md) |
 
 The native store preserves shared media when duplicating cards, disables a
 duplicated Source track, and retains its existing tag, role, track-group and
 folder validation. Deleting a folder preserves its media. Deleting an asset
 protects track-group members and media paths still shared by another card.
 This API does not add cross-Plan/branch usage analysis or rewrite prompt tags.
-Upload, derived-image jobs, whole-project duplication and the legacy import
-endpoint retain their existing behavior. Reviewed cross-project copies use the
-new command described below.
+Upload, model-based image jobs, whole-project duplication and the legacy
+import/derive endpoints retain their existing behavior. Reviewed cross-project
+copies and resampled image variants use staged commands.
 
 On success the response is `{catalog, receipt, replayed}`. Repeat only the exact
 request/operation ID after an uncertain result. A matching retained receipt is

--- a/project_assets.py
+++ b/project_assets.py
@@ -689,10 +689,16 @@ class ProjectAssetStore:
         return {key: value for key, value in document.items() if key != "library_receipts"}
 
     def public_catalog(self, project: Any, *, create: bool = True) -> dict[str, Any]:
+        if __package__:
+            from .asset_copy import pending_copies
+        else:
+            from asset_copy import pending_copies
         catalog = self.load(project, create=create)
         return {
             **{key: value for key, value in catalog.items() if key != "library_receipts"},
             "library_command_version": 1,
+            "library_copy_version": 1,
+            "library_pending_copies": pending_copies(self, catalog["project"], catalog),
             "library_revision": str(catalog.get("storage_revision") or "empty"),
             "assets": [dict(item) for item in catalog["assets"]],
             "reference_slots": [

--- a/project_assets.py
+++ b/project_assets.py
@@ -550,7 +550,7 @@ class ProjectAssetStore:
             if primary_error is not None:
                 raise primary_error
             catalog = self._empty_catalog(name)
-            if create:
+            if create and not getattr(self, "_library_command", None):
                 return self._save_catalog(catalog)
             return catalog
         if (not isinstance(catalog, dict)
@@ -578,6 +578,9 @@ class ProjectAssetStore:
         path = os.path.join(directory, "catalog.json")
         expected_storage_revision = str(
             catalog.get("storage_revision") or "")
+        pending = getattr(self, "_library_command", None)
+        if pending and (expected_storage_revision or "empty") != pending["before_revision"]:
+            raise ProjectAssetConflictError("The library changed after review; no edit was saved.")
         assets = [dict(item) for item in catalog.get("assets", [])
                   if isinstance(item, dict)]
         slots = [dict(item) for item in catalog.get("reference_slots", [])
@@ -626,6 +629,7 @@ class ProjectAssetStore:
         })
         document["storage_revision"] = uuid.uuid4().hex
         with _catalog_lock(path), _catalog_file_lock(path):
+            current = {}
             if os.path.isfile(path):
                 with open(path, "r", encoding="utf-8") as handle:
                     current = json.load(handle)
@@ -654,6 +658,24 @@ class ProjectAssetStore:
                 os.makedirs(os.path.join(directory, group), exist_ok=True)
             backup, _name = self._backup_dir(name)
             os.makedirs(backup, exist_ok=True)
+            # Conditional library receipts share the authoritative catalog
+            # commit. Keep them even when a legacy caller supplied a public
+            # catalog without internal command bookkeeping.
+            receipts = dict(current.get("library_receipts") or {})
+            pending = getattr(self, "_library_command", None)
+            if pending:
+                if pending["project"] != name:
+                    raise ValueError("Library command project changed.")
+                receipts[pending["operation_id"]] = {
+                    **{key: value for key, value in pending.items()
+                       if key not in ("asset_ids_before", "folder_ids_before")},
+                    "after_revision": document["storage_revision"],
+                    "committed_at": document["updated_at"],
+                    "created_assets": [item["id"] for item in assets if item["id"] not in pending["asset_ids_before"]],
+                    "created_folders": [item["id"] for item in folders if item["id"] not in pending["folder_ids_before"]],
+                }
+            if receipts:
+                document["library_receipts"] = receipts
             # The input-side catalog is authoritative and atomically durable.
             # Publish it first so an interrupted mirror refresh can never make
             # a speculative catalog look newer than the accepted project.
@@ -664,12 +686,14 @@ class ProjectAssetStore:
                 _LOG.warning(
                     "Project %s catalog committed, but its output recovery "
                     "mirror could not be refreshed: %s", name, exc)
-        return document
+        return {key: value for key, value in document.items() if key != "library_receipts"}
 
     def public_catalog(self, project: Any, *, create: bool = True) -> dict[str, Any]:
         catalog = self.load(project, create=create)
         return {
-            **catalog,
+            **{key: value for key, value in catalog.items() if key != "library_receipts"},
+            "library_command_version": 1,
+            "library_revision": str(catalog.get("storage_revision") or "empty"),
             "assets": [dict(item) for item in catalog["assets"]],
             "reference_slots": [
                 dict(item) for item in catalog.get("reference_slots", [])],
@@ -1354,11 +1378,16 @@ class ProjectAssetStore:
         catalog["assets"] = [
             item for item in catalog["assets"]
             if str(item.get("id") or "") != wanted]
-        remaining_paths = {
-            str(item.get("relative_path") or "")
-            for item in catalog["assets"]}
         saved = self._save_catalog(catalog)
 
+        deleted_files = self._delete_asset_files(project, removed, saved)
+        return {"catalog": saved, "asset": removed, "deleted_files": deleted_files}
+
+    def _delete_asset_files(self, project, removed, catalog):
+        wanted = str(removed["id"])
+        if any(str(item.get("id")) == wanted for item in catalog["assets"]):
+            return 0
+        remaining_paths = {str(item.get("relative_path") or "") for item in catalog["assets"]}
         deleted_files = 0
         relative = str(removed.get("relative_path") or "")
         if relative and relative not in remaining_paths:
@@ -1384,11 +1413,7 @@ class ProjectAssetStore:
                             and preview.name.startswith(preview_prefix)):
                         os.unlink(preview.path)
                         deleted_files += 1
-        return {
-            "catalog": saved,
-            "asset": removed,
-            "deleted_files": deleted_files,
-        }
+        return deleted_files
 
     def input_media(self, query: Any = "") -> list[dict[str, Any]]:
         needle = str(query or "").strip().lower()

--- a/project_assets.py
+++ b/project_assets.py
@@ -690,14 +690,16 @@ class ProjectAssetStore:
 
     def public_catalog(self, project: Any, *, create: bool = True) -> dict[str, Any]:
         if __package__:
-            from .asset_copy import pending_copies
+            from .asset_copy import pending_copies, pending_operations
         else:
-            from asset_copy import pending_copies
+            from asset_copy import pending_copies, pending_operations
         catalog = self.load(project, create=create)
         return {
             **{key: value for key, value in catalog.items() if key != "library_receipts"},
             "library_command_version": 1,
             "library_copy_version": 1,
+            "library_image_version": 1,
+            "library_pending_operations": pending_operations(self, catalog["project"], catalog),
             "library_pending_copies": pending_copies(self, catalog["project"], catalog),
             "library_revision": str(catalog.get("storage_revision") or "empty"),
             "assets": [dict(item) for item in catalog["assets"]],

--- a/project_assets.py
+++ b/project_assets.py
@@ -699,6 +699,7 @@ class ProjectAssetStore:
             "library_command_version": 1,
             "library_copy_version": 1,
             "library_image_version": 1,
+            "library_capture_version": 1,
             "library_pending_operations": pending_operations(self, catalog["project"], catalog),
             "library_pending_copies": pending_copies(self, catalog["project"], catalog),
             "library_revision": str(catalog.get("storage_revision") or "empty"),

--- a/tests/_asset_capture_commands_test.py
+++ b/tests/_asset_capture_commands_test.py
@@ -1,0 +1,206 @@
+"""Saved frame identity, publication, replay and ownership; CPU/temp media only."""
+import asyncio
+import copy
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from PIL import Image
+from aiohttp import web
+from _project_asset_manager_unit_test import ACTIVE, chain
+
+
+class CaptureCommands(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = pathlib.Path(temporary.name)
+        ACTIVE["root"] = str(self.root)
+        for kind in ("input", "output", "temp"):
+            (self.root / kind).mkdir()
+        self.store = chain._project_asset_store()
+        self.video = self.root / "output" / "saved.mkv"
+        subprocess.run(["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+            "-f", "lavfi", "-i", "color=c=red:s=64x48:r=24:d=1",
+            "-f", "lavfi", "-i", "color=c=blue:s=64x48:r=24:d=1",
+            "-filter_complex", "[0:v][1:v]concat=n=2:v=1:a=0", "-c:v", "ffv1", str(self.video)],
+            check=True, timeout=20)
+        self.revision = "a" * 32
+        self.metadata = self.root / "output" / "h3_chains" / "episode" / "checkpoints" / ("clip_0001.%s.json" % self.revision)
+        self.metadata.parent.mkdir(parents=True)
+        self.metadata.write_text(json.dumps({"run_name": "episode", "segment": {"index": 1,
+            "revision": self.revision, "id": "arrival", "segment": "saved.mkv",
+            "segment_sha256": chain._file_sha256(str(self.video)), "delivered_frames": 48}}))
+        self.body = {"command_version": 1, "project": "episode", "action": "asset_capture",
+            "operation_id": "b" * 32, "source": {"scene": 1, "revision": self.revision,
+                "branch_id": "main", "file": {"filename": "saved.mkv", "subfolder": "", "type": "output"}},
+            "time_seconds": 1.25, "tag": "arrival", "folder_id": ""}
+        self.proof = None
+        self.review()
+
+    def review(self):
+        value = chain.inspect_capture(self.store, "episode", self.body, chain._saved_capture_source)
+        self.body.update({key: value[key] for key in ("base_revision", "preview_revision")})
+        return value
+
+    def command(self):
+        return chain.command_capture(self.store, "episode", self.body, chain._saved_capture_source,
+            chain._capture_video_frame, lambda: chain._project_write_commit_guard("episode", self.proof, "capture"))
+
+    def claim(self, owner="capture-owner-a-1234567890", force=False):
+        value = chain.claim_project_ownership(str(self.root / "output"), "episode", owner, "test", force=force)
+        return {"owner_id": owner, "epoch": value["epoch"]}
+
+    def test_pixels_provenance_single_publication_and_idempotent_replay(self):
+        self.body["folder_id"] = self.store.create_folder("episode", "Captures")["folder"]["id"]
+        self.review()
+        before = self.video.read_bytes()
+        with patch.object(self.store, "_save_catalog", wraps=self.store._save_catalog) as save:
+            result = self.command()
+            self.assertEqual(save.call_count, 1)
+        entry = result["catalog"]["assets"][0]
+        with Image.open(self.store.asset("episode", entry["id"])[1]) as frame:
+            red, green, blue = frame.convert("RGB").getpixel((20, 20))
+            self.assertGreater(blue, 240)
+            self.assertLess(red + green, 10)
+        self.assertEqual(entry["source_origin"]["revision"], self.revision)
+        self.assertEqual(entry["source_origin"]["time_seconds"], 1.25)
+        self.assertEqual(entry["folder_id"], self.body["folder_id"])
+        self.assertEqual(entry["source_kind"], "frame_capture")
+        self.assertEqual(before, self.video.read_bytes())
+        with patch.object(chain, "_capture_video_frame") as extract:
+            self.assertTrue(self.command()["replayed"])
+            extract.assert_not_called()
+        self.assertEqual(len(self.store.load("episode")["assets"]), 1)
+        self.body["time_seconds"] = 0.5
+        with self.assertRaises(ValueError):
+            self.command()
+
+    def test_review_rejects_missing_wrong_or_changed_saved_source(self):
+        original = copy.deepcopy(self.body)
+        for change in ({"time_seconds": True}, {"time_seconds": -1}, {"time_seconds": 2},
+                {"source": {**original["source"], "revision": "c" * 32}},
+                {"source": {**original["source"], "file": {"filename": "saved.mkv", "subfolder": "../output", "type": "input"}}}):
+            self.body = {**original, **change}
+            with self.assertRaises((ValueError, FileNotFoundError)):
+                self.review()
+        self.body = original
+        self.metadata.write_text(self.metadata.read_text() + " ")
+        with self.assertRaises(chain.ProjectAssetConflictError):
+            self.command()
+        self.assertEqual(self.store.load("episode")["assets"], [])
+
+    def test_stale_library_and_takeover_during_extraction_do_not_publish(self):
+        self.store.create_folder("episode", "Changed")
+        with patch.object(chain, "_capture_video_frame") as extract:
+            with self.assertRaises(chain.ProjectAssetConflictError):
+                self.command()
+            extract.assert_not_called()
+        self.body["operation_id"] = "c" * 32
+        self.review()
+        self.proof = self.claim()
+        extract = chain._capture_video_frame
+        def takeover(*args):
+            extract(*args)
+            self.claim("capture-owner-b-1234567890", force=True)
+        with patch.object(chain, "_capture_video_frame", takeover):
+            with self.assertRaises(chain.ProjectOwnershipError):
+                self.command()
+        self.assertEqual(self.store.load("episode")["assets"], [])
+        self.assertFalse(list((self.root / "input").rglob("*.png")))
+
+    def test_prepared_frame_survives_restart_and_source_removal(self):
+        with patch.object(self.store, "_save_catalog", side_effect=OSError("disk busy")):
+            with self.assertRaises(OSError):
+                self.command()
+        self.store = chain._project_asset_store()
+        pending = chain.inspect_library(self.store, "episode", self.body["operation_id"])["pending_operation"]
+        self.assertEqual(pending["phase"], "prepared")
+        self.body = pending["request"]
+        self.video.unlink()
+        with patch.object(chain, "_capture_video_frame") as extract:
+            self.command()
+            extract.assert_not_called()
+        self.assertEqual(len(self.store.load("episode")["assets"]), 1)
+        self.assertEqual(self.store.public_catalog("episode")["library_pending_operations"], [])
+
+    def test_native_review_media_is_matched_to_its_revision_and_branch(self):
+        directory = self.root / "output" / "h3_chains" / "episode" / "reviews"
+        directory.mkdir()
+        name = "clip_0001.%s.example.review.mp4" % chain._file_sha256(str(self.video))[:12]
+        preview = directory / name
+        preview.write_bytes(self.video.read_bytes())
+        self.body["source"]["file"] = {"filename": name, "subfolder": "h3_chains/episode/reviews", "type": "output"}
+        self.review()
+        self.command()
+        origin = self.store.load("episode")["assets"][0]["source_origin"]
+        self.assertEqual(origin["file"]["filename"], name)
+        self.body["source"]["branch_id"] = "d" * 32
+        with self.assertRaises(ValueError):
+            self.review()
+        self.body["source"]["branch_id"] = "main"
+        unrelated = directory / "unrelated.mp4"
+        unrelated.write_bytes(preview.read_bytes())
+        self.body["source"]["file"]["filename"] = unrelated.name
+        with self.assertRaises(ValueError):
+            self.review()
+
+    def test_video_changes_or_extraction_failure_never_publish_partial_assets(self):
+        extract = chain._capture_video_frame
+        original = self.video.read_bytes()
+        def replace_source(*args):
+            extract(*args)
+            self.video.write_bytes(self.video.read_bytes() + b"changed")
+        with patch.object(chain, "_capture_video_frame", replace_source):
+            with self.assertRaises(chain.ProjectAssetConflictError):
+                self.command()
+        self.assertEqual(self.store.load("episode")["assets"], [])
+        with self.assertRaises(chain.ProjectAssetConflictError):
+            self.review()
+        self.video.write_bytes(original)
+        self.body["operation_id"] = "d" * 32
+        self.review()
+        with patch.object(chain, "_capture_video_frame", side_effect=RuntimeError("no frame")):
+            with self.assertRaisesRegex(ValueError, "no frame"):
+                self.command()
+        self.assertEqual(self.store.public_catalog("episode")["library_pending_operations"], [])
+
+    def test_capture_numbering_and_saved_receipt_survive_a_lost_commit_acknowledgement(self):
+        save = self.store._save_catalog
+        def lost(catalog):
+            save(catalog)
+            raise OSError("lost acknowledgement")
+        with patch.object(self.store, "_save_catalog", lost):
+            with self.assertRaises(OSError):
+                self.command()
+        self.store = chain._project_asset_store()
+        status = chain.inspect_library(self.store, "episode", self.body["operation_id"])
+        self.assertEqual(status["receipt"]["action"], "asset_capture")
+        self.assertTrue(self.command()["replayed"])
+        self.body["operation_id"] = "d" * 32
+        self.review()
+        self.command()
+        self.assertEqual([entry["tag"] for entry in self.store.load("episode")["assets"]], ["arrival", "arrival1"])
+
+    def test_route_ownership_and_uncertain_commit_receipt(self):
+        proof = self.claim()
+        body = self.body
+        class Request:
+            headers = {}
+            async def json(self):
+                return body
+        async def inline(function, *args, **kwargs):
+            return function(*args, **kwargs)
+        with patch.object(chain.asyncio, "to_thread", inline), patch.object(chain, "web", web):
+            self.assertEqual(asyncio.run(chain._project_asset_library(Request())).status, 423)
+            Request.headers = {"X-H3-Workflow-Owner": proof["owner_id"], "X-H3-Ownership-Epoch": str(proof["epoch"])}
+            result = asyncio.run(chain._project_asset_library(Request()))
+            self.assertEqual(result.status, 200, result.text)
+            self.assertEqual(json.loads(result.text)["receipt"]["action"], "asset_capture")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/_asset_copy_test.py
+++ b/tests/_asset_copy_test.py
@@ -1,0 +1,151 @@
+"""Temporary real catalogs/media exercise atomic group publication and recovery."""
+import copy
+import pathlib
+import tempfile
+import uuid
+import wave
+
+from PIL import Image
+import project_assets as native
+import asset_copy
+from asset_library import command_library, inspect_library
+
+
+def request(store, source, asset, *, enabled=True, target="film"):
+    review = asset_copy.preview_copy(store, target, source, asset, enabled)
+    return {"command_version": 1, "project": target, "action": "asset_copy",
+        "operation_id": uuid.uuid4().hex, "source_project": source, "asset_id": asset,
+        "enabled": enabled, "folder_id": "", "base_revision": review["base_revision"],
+        "preview_revision": review["preview_revision"]}
+
+
+def fails(kind, fn):
+    try:
+        fn()
+        raise AssertionError("Expected %s" % kind)
+    except kind:
+        pass
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    image = root / "hero.png"
+    Image.new("RGB", (24, 16), (80, 120, 160)).save(image)
+    audio = root / "song.wav"
+    with wave.open(str(audio), "wb") as handle:
+        handle.setnchannels(1); handle.setsampwidth(2); handle.setframerate(8000)
+        handle.writeframes(b"\0\0" * 8000)
+    store = native.ProjectAssetStore(str(root / "input"), str(root / "output"))
+    original = store.import_file("source", image, tag="hero")["asset"]
+    derived = store.duplicate("source", original["id"])["asset"]
+    mix = store.import_file("source", audio, tag="score", role="source_track")["asset"]
+    vocals = store.import_file("source", audio, tag="vocals", role="audio_reference")["asset"]
+    store.update("source", mix["id"], {"lyrics": "Full lyrics", "options": {"audio_tracks": {"full_mix": mix["id"], "vocals": vocals["id"], "instrumental": ""}}})
+    store.update("source", vocals["id"], {"enabled": False, "lyrics": "Stem lyrics"})
+    before = copy.deepcopy(store.load("source"))
+    group = request(store, "source", mix["id"])
+    atomic, commits = native._atomic_json, []
+    def record(path, value):
+        if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+            commits.append(copy.deepcopy(value))
+        atomic(path, value)
+    native._atomic_json = record
+    try:
+        result = command_library(store, "film", group)
+    finally:
+        native._atomic_json = atomic
+    assert len(commits) == 1 and len(commits[0]["assets"]) == 2
+    assert group["operation_id"] in commits[0]["library_receipts"]
+    first, stem = result["catalog"]["assets"]
+    assert first["options"]["audio_tracks"] == {"full_mix": first["id"], "vocals": stem["id"], "instrumental": ""}
+    assert first["lyrics"] == "Full lyrics" and stem["lyrics"] == "Stem lyrics" and not stem["enabled"]
+    assert first["source_origin"]["asset_id"] == mix["id"] and stem["source_origin"]["asset_id"] == vocals["id"]
+    assert store.load("source") == before
+    assert command_library(store, "film", group)["replayed"]
+    fails(ValueError, lambda: command_library(store, "film", {**group, "enabled": False}))
+    assert not asset_copy.preview_copy(store, "film", "source", mix["id"])["copyable"]
+    disabled = command_library(store, "film", request(store, "source", mix["id"], enabled=False))
+    assert sum(item["role"] == "source_track" and item["enabled"] for item in disabled["catalog"]["assets"]) == 1
+    picture = command_library(store, "film", request(store, "source", derived["id"]))
+    entry = picture["catalog"]["assets"][-1]
+    assert entry["source_origin"]["parent_asset_id"] == original["id"] and "parent_asset_id" not in entry
+    stale = request(store, "source", original["id"])
+    store.create_folder("source", "Changed source")
+    fails(native.ProjectAssetConflictError, lambda: command_library(store, "film", stale))
+    # Resolve missing group dependencies before any destination publication.
+    missing = request(store, "source", mix["id"], enabled=False, target="empty")
+    media = pathlib.Path(store.asset("source", vocals["id"])[1]); saved_bytes = media.read_bytes(); media.unlink()
+    fails(ValueError, lambda: command_library(store, "empty", missing))
+    assert not (root / "input/h3_projects/empty/catalog.json").exists()
+    media.write_bytes(saved_bytes)
+    # A crash after preparation retains frozen media and the exact request.
+    interrupted = request(store, "source", original["id"])
+    publish = asset_copy._publish_files
+    asset_copy._publish_files = lambda *args: (_ for _ in ()).throw(OSError("Disconnected before publication"))
+    try:
+        fails(OSError, lambda: command_library(store, "film", interrupted))
+    finally:
+        asset_copy._publish_files = publish
+    restarted = native.ProjectAssetStore(store.input_root, store.output_root)
+    pending = inspect_library(restarted, "film", interrupted["operation_id"])["pending_copy"]
+    assert pending["phase"] == "prepared" and pending["request"] == interrupted
+    assert restarted.public_catalog("film")["library_pending_copies"][0]["operation_id"] == interrupted["operation_id"]
+    store.update("source", original["id"], {"tag": "Changed_after_preparation"})
+    result = command_library(restarted, "film", interrupted)
+    assert not result["replayed"] and not result["catalog"]["library_pending_copies"]
+    assert len(result["receipt"]["created_assets"]) == 1
+    # Lost response after the atomic catalog is committed never copies twice.
+    lost = request(store, "source", original["id"])
+    def crash(path, value):
+        atomic(path, value)
+        if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+            raise OSError("Lost commit acknowledgement")
+    native._atomic_json = crash
+    try:
+        fails(OSError, lambda: command_library(store, "film", lost))
+    finally:
+        native._atomic_json = atomic
+    assert (pathlib.Path(asset_copy._directory(store, "film", lost["operation_id"])) / "stage").exists()
+    assert inspect_library(restarted, "film", lost["operation_id"])["receipt"]
+    assert not (pathlib.Path(asset_copy._directory(store, "film", lost["operation_id"])) / "stage").exists()
+    result = command_library(restarted, "film", lost)
+    assert result["replayed"] and len(result["receipt"]["created_assets"]) == 1
+    # A competing catalog writer after file promotion wins; only our files
+    # disappear, and the source and prior destination media remain intact.
+    race = request(store, "source", original["id"])
+    def raced(*args):
+        publish(*args)
+        restarted.create_folder("film", "Native concurrent folder")
+    asset_copy._publish_files = raced
+    try:
+        fails(native.ProjectAssetConflictError, lambda: command_library(store, "film", race))
+    finally:
+        asset_copy._publish_files = publish
+    assert not list((root / "input/h3_projects/film/images").glob(race["operation_id"] + "_*"))
+    assert all(pathlib.Path(store.asset("film", item["id"])[1]).exists() for item in store.load("film")["assets"])
+    assert inspect_library(store, "film", race["operation_id"])["pending_copy"] is None
+    fails(ValueError, lambda: command_library(store, "other", group))
+    # Existing bytes promoted before a server crash are reused on retry.
+    promoted = request(store, "source", original["id"])
+    def stop_after_files(*args):
+        publish(*args)
+        raise OSError("Server stopped after media promotion")
+    asset_copy._publish_files = stop_after_files
+    try:
+        fails(OSError, lambda: command_library(store, "film", promoted))
+    finally:
+        asset_copy._publish_files = publish
+    count = len(store.load("film")["assets"])
+    assert command_library(restarted, "film", promoted)["receipt"]["created_assets"]
+    assert len(store.load("film")["assets"]) == count + 1
+    # In-place source changes cannot be copied under an earlier reviewed hash.
+    drift = request(store, "source", original["id"], target="drift")
+    source_path = pathlib.Path(store.asset("source", original["id"])[1])
+    import os
+    stat = source_path.stat(); original_bytes = source_path.read_bytes()
+    changed_bytes = bytearray(original_bytes); changed_bytes[-1] ^= 1
+    source_path.write_bytes(changed_bytes); os.utime(source_path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    fails(native.ProjectAssetConflictError, lambda: command_library(store, "drift", drift))
+    source_path.write_bytes(original_bytes)
+    assert not (root / "input/h3_projects/drift/catalog.json").exists()
+print("Cross-project copy: native groups/provenance, atomic publication, conflicts, frozen-stage and commit recovery passed")

--- a/tests/_asset_image_test.py
+++ b/tests/_asset_image_test.py
@@ -1,0 +1,120 @@
+"""Real crop pixels, native geometry/provenance and interrupted image commands."""
+import copy
+import pathlib
+import tempfile
+import uuid
+
+from PIL import Image
+import project_assets as native
+import asset_copy
+from asset_image import inspect_image
+from asset_library import command_library, inspect_library
+
+
+def fails(kind, fn):
+    try:
+        fn()
+        raise AssertionError("Expected %s" % kind)
+    except kind:
+        pass
+
+
+def request(store, asset, **changes):
+    edit = {"crop": {"x": 8, "y": 0, "width": 8, "height": 16},
+        "target": {"width": 8, "height": 8}, "resample": "nearest", "tag": "blue_variant", "folder_id": "", **changes}
+    preview = inspect_image(store, "film", asset, edit)
+    return {"command_version": 1, "project": "film", "action": "asset_derive", "asset_id": asset,
+        "operation_id": uuid.uuid4().hex, "base_revision": preview["base_revision"],
+        "preview_revision": preview["preview_revision"], **edit}
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    image = Image.new("RGBA", (24, 16), (255, 0, 0, 255))
+    image.paste((0, 0, 255, 90), (8, 0, 16, 16))
+    path = root / "source.png"; image.save(path)
+    store = native.ProjectAssetStore(str(root / "input"), str(root / "output"))
+    parent = store.import_file("film", path, role="semantic_anchor", tag="hero")["asset"]
+    source_bytes = pathlib.Path(store.asset("film", parent["id"])[1]).read_bytes()
+    before = copy.deepcopy(store.load("film"))
+    info = inspect_image(store, "film", parent["id"])
+    assert info["source"] == {"width": 24, "height": 16} and info["max_pixels"] == native.MAX_DERIVED_IMAGE_PIXELS
+    command = request(store, parent["id"])
+    atomic, commits = native._atomic_json, []
+    def record(path, value):
+        if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+            commits.append(copy.deepcopy(value))
+        atomic(path, value)
+    native._atomic_json = record
+    try:
+        result = command_library(store, "film", command)
+    finally:
+        native._atomic_json = atomic
+    assert len(commits) == 1 and len(commits[0]["assets"]) == 2
+    entry = result["catalog"]["assets"][-1]
+    assert entry["parent_asset_id"] == parent["id"] and entry["role"] == "semantic_anchor"
+    assert entry["transform"]["crop"] == command["crop"] and entry["transform"]["resample"] == "nearest"
+    assert entry["transform"]["operation_id"] == command["operation_id"]
+    with Image.open(store.asset("film", entry["id"])[1]) as output:
+        assert output.size == (8, 8) and output.mode == "RGBA"
+        assert set(output.getdata()) == {(0, 0, 255, 90)}, "Crop placement/resampling lost the selected pixels or alpha"
+    assert store.load("film")["assets"][0] == before["assets"][0]
+    assert pathlib.Path(store.asset("film", parent["id"])[1]).read_bytes() == source_bytes
+    assert command_library(store, "film", command)["replayed"]
+    fails(ValueError, lambda: command_library(store, "film", {**command, "tag": "different"}))
+    fails(ValueError, lambda: request(store, parent["id"], crop={"x": 24, "y": 0, "width": 1, "height": 1}))
+    fails(ValueError, lambda: request(store, parent["id"], crop={"x": 1.5, "y": 0, "width": 1, "height": 1}))
+    fails(ValueError, lambda: request(store, parent["id"], target={"width": 100000, "height": 100000}))
+    fails(ValueError, lambda: request(store, parent["id"], resample="unknown"))
+    fails(ValueError, lambda: request(store, parent["id"], folder_id="missing"))
+    stale = request(store, parent["id"]); store.create_folder("film", "New native folder")
+    fails(native.ProjectAssetConflictError, lambda: command_library(store, "film", stale))
+    # EXIF-oriented dimensions are also used by the crop/resize engine.
+    rotated = root / "rotated.jpg"; exif = Image.Exif(); exif[274] = 6
+    Image.new("RGB", (30, 10), "green").save(rotated, exif=exif)
+    orientation = store.import_file("film", rotated)["asset"]
+    assert inspect_image(store, "film", orientation["id"])["source"] == {"width": 10, "height": 30}
+    oriented = request(store, orientation["id"], crop={"x": 0, "y": 10, "width": 10, "height": 20}, target={"width": 5, "height": 10})
+    result = command_library(store, "film", oriented)
+    assert result["catalog"]["assets"][-1]["transform"]["source"] == {"width": 10, "height": 30}
+    # Persisted image work remains distinguishable from cross-project imports.
+    paused = request(store, parent["id"])
+    publish = asset_copy._publish_files
+    asset_copy._publish_files = lambda *args: (_ for _ in ()).throw(OSError("Server interrupted"))
+    try:
+        fails(OSError, lambda: command_library(store, "film", paused))
+    finally:
+        asset_copy._publish_files = publish
+    restarted = native.ProjectAssetStore(store.input_root, store.output_root)
+    status = inspect_library(restarted, "film", paused["operation_id"])
+    assert status["pending_copy"] is None and status["pending_operation"]["request"] == paused
+    assert not status["catalog"]["library_pending_copies"]
+    assert status["catalog"]["library_pending_operations"][0]["action"] == "asset_derive"
+    assert command_library(restarted, "film", paused)["receipt"]["created_assets"]
+    # A lost acknowledgement reconciles the original image and clears its stage.
+    lost = request(store, parent["id"])
+    def crash(path, value):
+        atomic(path, value)
+        if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+            raise OSError("Lost catalog response")
+    native._atomic_json = crash
+    try:
+        fails(OSError, lambda: command_library(store, "film", lost))
+    finally:
+        native._atomic_json = atomic
+    count = len(store.load("film")["assets"])
+    assert inspect_library(restarted, "film", lost["operation_id"])["receipt"]
+    assert not (pathlib.Path(asset_copy._directory(store, "film", lost["operation_id"])) / "stage").exists()
+    assert command_library(restarted, "film", lost)["replayed"]
+    assert len(store.load("film")["assets"]) == count
+    # Retention limits reject before allocating another operation directory.
+    operations = pathlib.Path(asset_copy._directory(store, "film", lost["operation_id"])).parent
+    for number in range(1024):
+        if len(list(operations.iterdir())) >= 1024:
+            break
+        (operations / format(number, "032x")).mkdir(exist_ok=True)
+    limited = request(store, parent["id"])
+    fails(ValueError, lambda: command_library(store, "film", limited))
+    assert len(list(operations.iterdir())) == 1024
+    assert command_library(store, "film", lost)["replayed"], "The retention limit blocked a committed receipt"
+print("Image variants: native crop pixels/alpha/orientation, one catalog commit, provenance, stale review and restart recovery passed")

--- a/tests/_asset_library_api_test.py
+++ b/tests/_asset_library_api_test.py
@@ -1,0 +1,60 @@
+"""Real library handlers, temporary projects and CPU-only ComfyUI stubs."""
+import asyncio
+import json
+import pathlib
+import runpy
+import sys
+import tempfile
+import uuid
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+chain = runpy.run_path(str(ROOT / "tests/_chapter_delivery_unit_test.py"))["chain"]
+
+
+class Request:
+    def __init__(self, body=None, **query):
+        self.body, self.query, self.headers = body, query, {}
+        self.method = "GET" if body is None else "POST"
+    async def json(self):
+        return self.body
+
+
+async def main():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = pathlib.Path(temporary)
+        chain._input_root = lambda: str(root / "input")
+        chain._output_root = lambda: str(root / "output")
+        catalog = json.loads((await chain._project_asset_catalog(Request(project="film", create="false"))).text)
+        assert catalog["library_revision"] == "empty" and not list(root.rglob("catalog.json"))
+        command = {"command_version": 1, "operation_id": uuid.uuid4().hex,
+                   "base_revision": "empty", "action": "folder_create", "project": "film", "name": "Cast"}
+        result = await chain._project_asset_library(Request(command))
+        assert result.status == 200, result.text
+        saved = json.loads(result.text)
+        assert saved["catalog"]["folders"][0]["name"] == "Cast"
+        assert json.loads((await chain._project_asset_library(Request(command))).text)["replayed"]
+        stale = await chain._project_asset_library(Request({**command, "operation_id": uuid.uuid4().hex}))
+        assert stale.status == 409, stale.text
+        module = sys.modules[chain.ProjectAssetStore.__module__]
+        atomic = module._atomic_json
+        def crash(path, value):
+            atomic(path, value)
+            if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+                raise OSError("Simulated interrupted response")
+        second = {**command, "operation_id": uuid.uuid4().hex, "name": "Places", "base_revision": saved["catalog"]["library_revision"]}
+        module._atomic_json = crash
+        try:
+            failure = await chain._project_asset_library(Request(second))
+            assert failure.status == 500, failure.text
+        finally:
+            module._atomic_json = atomic
+        status = json.loads((await chain._project_asset_catalog(Request(project="film", operation_id=second["operation_id"]))).text)
+        assert status["receipt"]["operation_id"] == second["operation_id"] and len(status["catalog"]["folders"]) == 2
+        chain.claim_project_ownership(str(root / "output"), "film", "workflow-owner-a-1234567890", "Owner")
+        denied = await chain._project_asset_library(Request({**command, "operation_id": uuid.uuid4().hex}))
+        assert denied.status == 423, denied.text
+        assert len(chain._project_asset_store().load("film")["folders"]) == 2
+    print("Asset library HTTP: read without creation, native commands, receipts, 409/500 recovery and 423 ownership passed")
+
+
+asyncio.run(main())

--- a/tests/_asset_library_api_test.py
+++ b/tests/_asset_library_api_test.py
@@ -50,9 +50,23 @@ async def main():
             module._atomic_json = atomic
         status = json.loads((await chain._project_asset_catalog(Request(project="film", operation_id=second["operation_id"]))).text)
         assert status["receipt"]["operation_id"] == second["operation_id"] and len(status["catalog"]["folders"]) == 2
+        from PIL import Image
+        image = root / "picture.png"; Image.new("RGB", (24, 16)).save(image)
+        source = chain._project_asset_store().import_file("source", image)["asset"]
+        preview_response = await chain._project_asset_catalog(Request(project="film", copy_source="source", copy_asset=source["id"], enabled="false"))
+        assert preview_response.status == 200, preview_response.text
+        preview = json.loads(preview_response.text)
+        copy_request = {"command_version": 1, "project": "film", "action": "asset_copy", "operation_id": uuid.uuid4().hex,
+            "source_project": "source", "asset_id": source["id"], "enabled": False, "folder_id": "",
+            "base_revision": preview["base_revision"], "preview_revision": preview["preview_revision"]}
+        copied = await chain._project_asset_library(Request(copy_request))
+        assert copied.status == 200, copied.text
+        assert json.loads(copied.text)["catalog"]["assets"][0]["source_origin"]["project"] == "source"
+        assert json.loads((await chain._project_asset_library(Request(copy_request))).text)["replayed"]
         chain.claim_project_ownership(str(root / "output"), "film", "workflow-owner-a-1234567890", "Owner")
         denied = await chain._project_asset_library(Request({**command, "operation_id": uuid.uuid4().hex}))
         assert denied.status == 423, denied.text
+        assert (await chain._project_asset_library(Request({**copy_request, "operation_id": uuid.uuid4().hex}))).status == 423
         assert len(chain._project_asset_store().load("film")["folders"]) == 2
     print("Asset library HTTP: read without creation, native commands, receipts, 409/500 recovery and 423 ownership passed")
 

--- a/tests/_asset_library_api_test.py
+++ b/tests/_asset_library_api_test.py
@@ -63,10 +63,23 @@ async def main():
         assert copied.status == 200, copied.text
         assert json.loads(copied.text)["catalog"]["assets"][0]["source_origin"]["project"] == "source"
         assert json.loads((await chain._project_asset_library(Request(copy_request))).text)["replayed"]
+        parent_id = json.loads(copied.text)["catalog"]["assets"][0]["id"]
+        image_edit = {"crop": {"x": 0, "y": 0, "width": 8, "height": 8}, "target": {"width": 4, "height": 4}, "resample": "nearest", "tag": "small_picture", "folder_id": ""}
+        image_info = await chain._project_asset_catalog(Request(project="film", image_asset=parent_id, image_edit=json.dumps(image_edit)))
+        assert image_info.status == 200, image_info.text
+        image_info = json.loads(image_info.text)
+        assert image_info["source"] == {"width": 24, "height": 16}
+        image_request = {"command_version": 1, "project": "film", "action": "asset_derive", "operation_id": uuid.uuid4().hex, "asset_id": parent_id,
+            "base_revision": image_info["base_revision"], "preview_revision": image_info["preview_revision"], **image_edit}
+        variant = await chain._project_asset_library(Request(image_request))
+        assert variant.status == 200, variant.text
+        assert json.loads(variant.text)["catalog"]["assets"][-1]["parent_asset_id"] == parent_id
+        assert json.loads((await chain._project_asset_library(Request(image_request))).text)["replayed"]
         chain.claim_project_ownership(str(root / "output"), "film", "workflow-owner-a-1234567890", "Owner")
         denied = await chain._project_asset_library(Request({**command, "operation_id": uuid.uuid4().hex}))
         assert denied.status == 423, denied.text
         assert (await chain._project_asset_library(Request({**copy_request, "operation_id": uuid.uuid4().hex}))).status == 423
+        assert (await chain._project_asset_library(Request({**image_request, "operation_id": uuid.uuid4().hex}))).status == 423
         assert len(chain._project_asset_store().load("film")["folders"]) == 2
     print("Asset library HTTP: read without creation, native commands, receipts, 409/500 recovery and 423 ownership passed")
 

--- a/tests/_asset_library_commands_test.py
+++ b/tests/_asset_library_commands_test.py
@@ -1,0 +1,123 @@
+"""Library commands use native metadata/media semantics with durable receipts."""
+import pathlib
+import json
+import tempfile
+import uuid
+
+from PIL import Image
+import project_assets as native
+from asset_library import command_library, inspect_library
+
+
+def request(store, action, **fields):
+    return {"command_version": 1, "operation_id": uuid.uuid4().hex,
+            "action": action, "base_revision": store.public_catalog("film", create=False)["library_revision"], **fields}
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    loose = root / "input" / "loose.png"; loose.parent.mkdir()
+    Image.new("RGB", (24, 16), (80, 120, 160)).save(loose)
+    store = native.ProjectAssetStore(str(root / "input"), str(root / "output"))
+    fresh = request(store, "folder_create", name="Cast")
+    assert fresh["base_revision"] == "empty" and not list(root.rglob("catalog.json"))
+    result = command_library(store, "film", fresh)
+    folder = result["receipt"]["created_folders"][0]
+    assert result["catalog"]["folders"][0]["id"] == folder
+    assert "library_receipts" not in result["catalog"]
+    assert command_library(store, "film", fresh)["replayed"]
+    original = store.import_file("film", loose, tag="hero")["asset"]
+    # A legacy import retains the earlier command receipt.
+    assert inspect_library(store, "film", fresh["operation_id"])["receipt"]
+    move = request(store, "asset_update", asset_id=original["id"], changes={"folder_id": folder})
+    command_library(store, "film", move)
+    before = store.public_catalog("film")
+    stale = request(store, "asset_duplicate", asset_id=original["id"])
+    command_library(store, "film", request(store, "folder_update", folder_id=folder, changes={"color": "#336699"}))
+    after = store.public_catalog("film")
+    assert after["revision"] == before["revision"] and after["library_revision"] != before["library_revision"]
+    try:
+        command_library(store, "film", stale)
+        raise AssertionError("Folder-only change did not invalidate review")
+    except native.ProjectAssetConflictError:
+        pass
+    # Stop after authoritative catalog commit but before a response/mirror.
+    duplicate = request(store, "asset_duplicate", asset_id=original["id"])
+    atomic = native._atomic_json
+    def crash(path, value):
+        atomic(path, value)
+        if pathlib.Path(path) == root / "input/h3_projects/film/catalog.json":
+            raise OSError("Lost catalog acknowledgement")
+    native._atomic_json = crash
+    try:
+        command_library(store, "film", duplicate)
+        raise AssertionError("Expected interrupted response")
+    except OSError:
+        pass
+    finally:
+        native._atomic_json = atomic
+    restarted = native.ProjectAssetStore(str(root / "input"), str(root / "output"))
+    result = command_library(restarted, "film", duplicate)
+    assert result["replayed"] and len(result["catalog"]["assets"]) == 2
+    clone = next(item for item in result["catalog"]["assets"] if item["id"] != original["id"])
+    assert clone["parent_asset_id"] == original["id"] and clone["relative_path"] == original["relative_path"]
+    try:
+        command_library(store, "film", {**duplicate, "tag": "Different"})
+        raise AssertionError("Changed retry accepted")
+    except ValueError:
+        pass
+    command_library(store, "film", request(store, "asset_reorder", asset_ids=[clone["id"], original["id"]]))
+    assert store.load("film")["assets"][0]["id"] == clone["id"]
+    command_library(store, "film", request(store, "folder_delete", folder_id=folder))
+    assert all(not item["folder_id"] for item in store.load("film")["assets"])
+    command_library(store, "film", request(store, "asset_delete", asset_id=original["id"]))
+    owned_path = pathlib.Path(store.asset("film", clone["id"])[1])
+    assert owned_path.exists(), "Deleting one card removed another card's shared media"
+    removal = request(store, "asset_delete", asset_id=clone["id"])
+    cleanup = store._delete_asset_files
+    store._delete_asset_files = lambda *args: (_ for _ in ()).throw(OSError("Interrupted cleanup"))
+    try:
+        command_library(store, "film", removal)
+        raise AssertionError("Expected interrupted cleanup")
+    except OSError:
+        pass
+    finally:
+        store._delete_asset_files = cleanup
+    assert owned_path.exists() and store.load("film")["assets"] == []
+    assert inspect_library(restarted, "film", removal["operation_id"])["receipt"]
+    assert not owned_path.exists(), "Status confirmation left committed deletion cleanup unfinished"
+    assert command_library(restarted, "film", removal)["replayed"]
+    assert not owned_path.exists() and loose.exists()
+    # A mutation between outer review validation and a native method's reload
+    # must still fail before committing, as can happen in another process.
+    value = store.create_folder("film", "Locations")["folder"]
+    pending = request(store, "folder_update", folder_id=value["id"], changes={"name": "Stale rename"})
+    load, calls = store.load, [0]
+    def racing_load(project, **kwargs):
+        calls[0] += 1
+        if calls[0] == 2:
+            restarted.update_folder(project, value["id"], {"name": "New native name"})
+        return load(project, **kwargs)
+    store.load = racing_load
+    try:
+        command_library(store, "film", pending)
+        raise AssertionError("Intervening native reload was overwritten")
+    except native.ProjectAssetConflictError:
+        pass
+    finally:
+        store.load = load
+    assert store.load("film")["folders"][0]["name"] == "New native name"
+    # A legacy/public snapshot cannot discard retained operation identities.
+    store._save_catalog(store.public_catalog("film", create=False))
+    assert inspect_library(store, "film", fresh["operation_id"])["receipt"]
+    # Even a copied catalog cannot authorize the source project's operation.
+    copied = root / "input/h3_projects/other/catalog.json"
+    copied.parent.mkdir(parents=True)
+    copied.write_text(json.dumps(store.load("film")))
+    assert inspect_library(store, "other", fresh["operation_id"])["receipt"] is None
+    try:
+        command_library(store, "other", fresh)
+        raise AssertionError("Copied source-project receipt was replayed")
+    except ValueError:
+        pass
+print("Asset library: folders, membership, ordering, native duplication/deletion, receipts, restart and stale edits passed")


### PR DESCRIPTION
An open companion library can become stale while the native Carousel changes a folder or asset. Existing grouped imports, image variants and frame captures also lack a shared reviewed operation/receipt boundary. This change adds conditional library commands and stages media before one complete destination catalog commit.

- Folder, membership, order, metadata, duplicate and delete commands require the reviewed storage revision and native ownership. Receipts commit with the authoritative catalog and survive legacy writes; exact replay cannot repeat duplication or deletion.
- Cross-project previews identify source/target catalogs, media dependencies and destination folder/enabled intent. The native importer supplies tag, role, lyric and track semantics in a private store. Copies remap audio IDs and retain source/derived provenance.
- Image review uses native oriented geometry, crop/target limits and resampling. Variants freeze source bytes and invoke the existing derive/register methods in staging; the picture and parent/transform provenance publish together.
- Saved-frame capture validates the displayed checkpoint revision and raw/review video, branch, file confinement, SHA-256 identities and clip-local time. Native FFmpeg extraction and picture import retain numbered tags, destination folder and saved-clip/time provenance. The original capture endpoint remains compatible.
- Prepared media and exact requests survive restart. Operation locks serialize retries, storage CAS rejects stale publication, and committed receipts reconcile lost acknowledgements. Captures resume from the prepared image without re-extracting the source. Rejected publication removes only that operation's unreferenced media.
- Reviewed media uses consistent operation → ownership → catalog lock ordering. Admission checks ownership; preparation permits takeover, and a short ownership guard fences final media promotion/publication. All staged actions follow the same order.
- Public capabilities and pending-operation identities support conditional companion controls. Admission rejects before allocating directories at the shared retained-operation limit; committed receipts remain replayable. Legacy native clients retain their endpoints and semantics.

Validation uses CPU stubs and temporary projects/videos. Native command, store and real-route checks cover selected pixels/alpha/EXIF orientation, requested-time video colors, exact saved/review identities, groups/provenance, ownership takeover, missing/damaged media, stale reviews, one authoritative commit, preparation/promotion/catalog interruption, restart/exact replay and operation limits. The 16 legacy capture tests pass. SceneWeaver 0.5.15 passes its build, 37 frontend + 147 adapter/proxy tests and 144 browser cases, including compact capture-dialog inspection. No production project or GPU workflow was used.

This remains a draft targeting nightly. Representative production validation, isolated model upscale, global usage analysis and the remaining workflow-parity work stay open. API/persistence details are in `docs/asset-library-commands.md`, `docs/asset-image-commands.md` and `docs/asset-capture-commands.md`, including retained-operation limits, the primary/mirror boundary and best-effort staging cleanup.
